### PR TITLE
Add Linting Infrastructure with CI workflow

### DIFF
--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -1,3 +1,4 @@
+---
 name: 'Setup Python CI'
 description: 'Sets up Python and uv package manager with dependencies'
 
@@ -5,6 +6,10 @@ inputs:
   python-version:
     description: 'Python version to use'
     required: true
+  extra:
+    description: 'uv extra group to install (defaults to ci)'
+    required: false
+    default: ci
 
 runs:
   using: 'composite'
@@ -25,5 +30,4 @@ runs:
 
     - name: Install dependencies from lock file
       shell: bash
-      run: uv sync --extra ci
-
+      run: uv sync --extra ${{ inputs.extra }}

--- a/.github/scripts/check_imports/__init__.py
+++ b/.github/scripts/check_imports/__init__.py
@@ -1,0 +1,19 @@
+from .check_imports import (
+    ImportGuardConfig,
+    TopLevelImportVisitor,
+    build_stdlib_index,
+    canonicalize_module_name,
+    check_imports,
+    discover_python_files,
+    extract_top_level_imports,
+)
+
+__all__ = [
+    "ImportGuardConfig",
+    "TopLevelImportVisitor",
+    "build_stdlib_index",
+    "canonicalize_module_name",
+    "check_imports",
+    "discover_python_files",
+    "extract_top_level_imports",
+]

--- a/.github/scripts/check_imports/check_imports.py
+++ b/.github/scripts/check_imports/check_imports.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Validate module-level imports are limited to Python's standard library.
+
+This script enforces the repository’s import guard strategy: third-party or
+heavy dependencies must be imported within the function or pipeline body rather
+than at module import time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+import yaml
+
+DEFAULT_CONFIG_PATH = Path(__file__).parent / "import_exceptions.yaml"
+
+
+class ImportGuardConfig:
+    """Holds allow-list data for the import guard."""
+
+    def __init__(
+        self,
+        module_allowlist: Optional[Iterable[str]] = None,
+        path_scoped_allowlist: Optional[dict[str, Iterable[str]]] = None,
+    ) -> None:
+        """Initialize configuration from module and path allow lists."""
+        self.module_allowlist: set[str] = {canonicalize_module_name(item) for item in module_allowlist or []}
+        self.path_scoped_allowlist: dict[Path, set[str]] = {}
+        for raw_path, modules in (path_scoped_allowlist or {}).items():
+            normalized = Path(raw_path).resolve()
+            self.path_scoped_allowlist[normalized] = {canonicalize_module_name(mod) for mod in modules}
+
+    @classmethod
+    def from_path(cls, path: Path) -> "ImportGuardConfig":
+        """Instantiate configuration from a YAML file."""
+        if not path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {path}")
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        modules = data.get("modules", [])
+        path_scoped = data.get("files", {})
+        return cls(modules, path_scoped)
+
+    def is_allowed(self, module: str, file_path: Path) -> bool:
+        """Return True when a module is allow-listed for the given file path."""
+        canonical_module = canonicalize_module_name(module)
+        if canonical_module in self.module_allowlist:
+            return True
+        resolved = file_path
+        modules = self.path_scoped_allowlist.get(resolved)
+        if modules:
+            return canonical_module in modules
+        for parent in resolved.parents:
+            modules = self.path_scoped_allowlist.get(parent)
+            if modules and canonical_module in modules:
+                return True
+        return False
+
+
+def canonicalize_module_name(name: str) -> str:
+    """Return the top-level portion of a dotted module path."""
+    return name.split(".")[0]
+
+
+def discover_python_files(paths: Sequence[str]) -> list[Path]:
+    """Collect Python files from individual files or by walking directories."""
+    python_files: list[Path] = []
+
+    for raw_path in paths:
+        path = Path(raw_path)
+        # Skip hidden files/directories in any part of the path
+        if any(part.startswith(".") for part in path.parts):
+            continue
+        if path.is_file() and path.suffix == ".py":
+            python_files.append(path)
+        elif path.is_dir():
+            for candidate in path.rglob("*.py"):
+                if any(part.startswith(".") for part in candidate.parts):
+                    continue
+                python_files.append(candidate)
+
+    return python_files
+
+
+@lru_cache(maxsize=1)
+def build_stdlib_index() -> frozenset[str]:
+    """Return a set containing names of standard-library modules."""
+    candidates: set[str] = set(sys.builtin_module_names)
+    candidates.update(canonicalize_module_name(name) for name in sys.stdlib_module_names)
+    return frozenset(candidates)
+
+
+class TopLevelImportVisitor(ast.NodeVisitor):
+    """Collect absolute imports that appear at module scope."""
+
+    def __init__(self) -> None:
+        """Initialize storage for discovered imports."""
+        self.imports: list[tuple[str, int]] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """Don't descend into functions."""
+        return
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        """Don't descend into async functions."""
+        return
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """Don't descend into classes."""
+        return
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """Record absolute `import foo` statements."""
+        for alias in node.names:
+            if alias.name:
+                self.imports.append((canonicalize_module_name(alias.name), node.lineno))
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """Record absolute `from foo import bar` statements."""
+        if node.level == 0 and node.module:
+            self.imports.append((canonicalize_module_name(node.module), node.lineno))
+
+    def generic_visit(self, node: ast.AST) -> None:
+        """Continue walking child nodes unless blocked by other handlers."""
+        for child in ast.iter_child_nodes(node):
+            self.visit(child)
+
+
+def extract_top_level_imports(node: ast.AST) -> Iterable[tuple[str, int]]:
+    """Yield (module, line) tuples for top-level import statements."""
+    visitor = TopLevelImportVisitor()
+    visitor.visit(node)
+    return visitor.imports
+
+
+def check_imports(files: Sequence[Path], config: ImportGuardConfig, *, quiet: bool = False) -> int:
+    """Validate import style across a collection of Python files."""
+    stdlib_modules = build_stdlib_index()
+    violations: list[str] = []
+
+    for file_path in files:
+        resolved_path = file_path.resolve()
+        try:
+            with resolved_path.open("r", encoding="utf-8") as handle:
+                tree = ast.parse(handle.read(), filename=str(resolved_path))
+        except SyntaxError as exc:
+            violations.append(f"{resolved_path}: failed to parse ({exc})")
+            continue
+
+        for module_name, lineno in extract_top_level_imports(tree):
+            if module_name in stdlib_modules:
+                continue
+            if config.is_allowed(module_name, resolved_path):
+                continue
+            violations.append(
+                f"{resolved_path}:{lineno} imports non-stdlib module '{module_name}' at top level",
+            )
+
+    if violations:
+        for entry in violations:
+            print(entry, file=sys.stderr)
+        print("You may add exceptions in the configuration if any of these modules are required")
+        return 1
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Ensure top-level Python imports are limited to the standard library.")
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG_PATH),
+        help="Path to YAML configuration file with allowed modules/files.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress warning output; only emit errors.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Files or directories to inspect.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the import guard script."""
+    args = parse_args()
+    python_files = discover_python_files(args.paths)
+    if not python_files:
+        print("No Python files found to inspect.", file=sys.stderr)
+        return 0
+    config = ImportGuardConfig.from_path(Path(args.config))
+    return check_imports(python_files, config, quiet=args.quiet)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_imports/import_exceptions.yaml
+++ b/.github/scripts/check_imports/import_exceptions.yaml
@@ -1,0 +1,5 @@
+---
+modules:
+  - pytest
+  - kfp
+files: {}

--- a/.github/scripts/check_imports/tests/test_check_imports.py
+++ b/.github/scripts/check_imports/tests/test_check_imports.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Unit tests for check_imports.py script."""
+
+from __future__ import annotations
+
+import ast
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from check_imports import (
+    ImportGuardConfig,
+    build_stdlib_index,
+    canonicalize_module_name,
+    check_imports,
+    discover_python_files,
+    extract_top_level_imports,
+)
+
+
+class TestCanonicalizeModuleName:
+    """Test the canonicalize_module_name function."""
+
+    def test_simple_module_name(self):
+        """Test canonicalizing a simple module name."""
+        assert canonicalize_module_name("os") == "os"
+        assert canonicalize_module_name("sys") == "sys"
+
+    def test_dotted_module_name(self):
+        """Test canonicalizing a dotted module path."""
+        assert canonicalize_module_name("os.path") == "os"
+        assert canonicalize_module_name("collections.abc") == "collections"
+        assert canonicalize_module_name("email.mime.text") == "email"
+
+    def test_empty_string(self):
+        """Test canonicalizing an empty string."""
+        assert canonicalize_module_name("") == ""
+
+
+class TestImportGuardConfig:
+    """Test the ImportGuardConfig class."""
+
+    def test_init_empty(self):
+        """Test initializing with no allowlists."""
+        config = ImportGuardConfig()
+        assert config.module_allowlist == set()
+        assert config.path_scoped_allowlist == {}
+
+    def test_init_with_modules(self):
+        """Test initializing with module allowlist."""
+        config = ImportGuardConfig(module_allowlist=["pandas", "numpy"])
+        assert "pandas" in config.module_allowlist
+        assert "numpy" in config.module_allowlist
+
+    def test_init_with_dotted_modules(self):
+        """Test initializing with dotted module names."""
+        config = ImportGuardConfig(module_allowlist=["pandas.core", "numpy.array"])
+        assert "pandas" in config.module_allowlist
+        assert "numpy" in config.module_allowlist
+
+    def test_init_with_path_scoped(self):
+        """Test initializing with path-scoped allowlist."""
+        config = ImportGuardConfig(
+            path_scoped_allowlist={
+                "scripts": ["pytest"],
+                "tests": ["mock"],
+            }
+        )
+        scripts_path = Path("scripts").resolve()
+        tests_path = Path("tests").resolve()
+        assert scripts_path in config.path_scoped_allowlist
+        assert tests_path in config.path_scoped_allowlist
+        assert "pytest" in config.path_scoped_allowlist[scripts_path]
+        assert "mock" in config.path_scoped_allowlist[tests_path]
+
+    def test_from_path_nonexistent(self):
+        """Test loading config from nonexistent file raises error."""
+        with pytest.raises(FileNotFoundError, match="Configuration file not found"):
+            ImportGuardConfig.from_path(Path("/nonexistent/file.yaml"))
+
+    def test_from_path_valid_file(self):
+        """Test loading config from valid YAML file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as f:
+            yaml.dump(
+                {
+                    "modules": ["pandas", "numpy"],
+                    "files": {
+                        "scripts": ["pytest"],
+                    },
+                },
+                f,
+            )
+            config_path = Path(f.name)
+
+        try:
+            config = ImportGuardConfig.from_path(config_path)
+            assert "pandas" in config.module_allowlist
+            assert "numpy" in config.module_allowlist
+            scripts_path = Path("scripts").resolve()
+            assert scripts_path in config.path_scoped_allowlist
+        finally:
+            config_path.unlink()
+
+    def test_is_allowed_global_module(self):
+        """Test checking if a module is globally allowed."""
+        config = ImportGuardConfig(module_allowlist=["pandas", "numpy"])
+        assert config.is_allowed("pandas", Path("any/file.py"))
+        assert config.is_allowed("numpy", Path("another/file.py"))
+        assert not config.is_allowed("tensorflow", Path("file.py"))
+
+    def test_is_allowed_path_scoped(self):
+        """Test checking if a module is allowed for specific path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir).resolve()
+            test_file = tmpdir_path / "test.py"
+            test_file.touch()
+
+            config = ImportGuardConfig(
+                path_scoped_allowlist={
+                    str(tmpdir_path): ["pytest"],
+                }
+            )
+
+            assert config.is_allowed("pytest", test_file)
+            assert not config.is_allowed("mock", test_file)
+
+    def test_is_allowed_parent_path_scoped(self):
+        """Test checking if a module is allowed via parent directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir).resolve()
+            subdir = tmpdir_path / "subdir"
+            subdir.mkdir()
+            test_file = subdir / "test.py"
+            test_file.touch()
+
+            config = ImportGuardConfig(
+                path_scoped_allowlist={
+                    str(tmpdir_path): ["pytest"],
+                }
+            )
+
+            assert config.is_allowed("pytest", test_file)
+
+
+class TestDiscoverPythonFiles:
+    """Test the discover_python_files function."""
+
+    def test_single_file(self):
+        """Test discovering a single Python file."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            file_path = Path(f.name)
+
+        try:
+            files = discover_python_files([str(file_path)])
+            assert len(files) == 1
+            assert files[0] == file_path
+        finally:
+            file_path.unlink()
+
+    def test_non_python_file(self):
+        """Test that non-Python files are ignored."""
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            file_path = Path(f.name)
+
+        try:
+            files = discover_python_files([str(file_path)])
+            assert len(files) == 0
+        finally:
+            file_path.unlink()
+
+    def test_directory_recursive(self):
+        """Test discovering Python files recursively in a directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            (tmpdir_path / "file1.py").touch()
+            (tmpdir_path / "file2.py").touch()
+            subdir = tmpdir_path / "subdir"
+            subdir.mkdir()
+            (subdir / "file3.py").touch()
+            (tmpdir_path / "notpython.txt").touch()
+
+            files = discover_python_files([str(tmpdir_path)])
+            assert len(files) == 3
+            file_names = {f.name for f in files}
+            assert file_names == {"file1.py", "file2.py", "file3.py"}
+
+    def test_skip_hidden_files(self):
+        """Test that hidden files are skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            (tmpdir_path / "visible.py").touch()
+            (tmpdir_path / ".hidden.py").touch()
+
+            files = discover_python_files([str(tmpdir_path)])
+            assert len(files) == 1
+            assert files[0].name == "visible.py"
+
+    def test_skip_hidden_directories(self):
+        """Test that files in hidden directories are skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            (tmpdir_path / "visible.py").touch()
+            hidden_dir = tmpdir_path / ".hidden"
+            hidden_dir.mkdir()
+            (hidden_dir / "file.py").touch()
+
+            files = discover_python_files([str(tmpdir_path)])
+            assert len(files) == 1
+            assert files[0].name == "visible.py"
+
+    def test_multiple_paths(self):
+        """Test discovering files from multiple paths."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            dir1 = tmpdir_path / "dir1"
+            dir1.mkdir()
+            dir2 = tmpdir_path / "dir2"
+            dir2.mkdir()
+
+            (dir1 / "file1.py").touch()
+            (dir2 / "file2.py").touch()
+
+            files = discover_python_files([str(dir1), str(dir2)])
+            assert len(files) == 2
+
+
+class TestTopLevelImportVisitor:
+    """Test the TopLevelImportVisitor class."""
+
+    def test_simple_import(self):
+        """Test extracting simple import statements."""
+        code = "import os\nimport sys"
+        tree = ast.parse(code)
+        imports = extract_top_level_imports(tree)
+        import_list = list(imports)
+        assert len(import_list) == 2
+        assert ("os", 1) in import_list
+        assert ("sys", 2) in import_list
+
+    def test_from_import(self):
+        """Test extracting from...import statements."""
+        code = "from os import path\nfrom collections import defaultdict"
+        tree = ast.parse(code)
+        imports = extract_top_level_imports(tree)
+        import_list = list(imports)
+        assert len(import_list) == 2
+        assert ("os", 1) in import_list
+        assert ("collections", 2) in import_list
+
+    def test_dotted_import(self):
+        """Test extracting dotted imports."""
+        code = "import os.path\nimport email.mime.text"
+        tree = ast.parse(code)
+        imports = extract_top_level_imports(tree)
+        import_list = list(imports)
+        assert len(import_list) == 2
+        assert ("os", 1) in import_list
+        assert ("email", 2) in import_list
+
+    def test_relative_import_ignored(self):
+        """Test that relative imports are ignored."""
+        code = "from . import module\nfrom ..package import something"
+        tree = ast.parse(code)
+        imports = extract_top_level_imports(tree)
+        import_list = list(imports)
+        assert len(import_list) == 0
+
+    def test_function_level_import_ignored(self):
+        """Test that imports inside functions are ignored."""
+        code = """
+import os
+
+def foo():
+    import pandas
+    return pandas
+"""
+        tree = ast.parse(code)
+        imports = extract_top_level_imports(tree)
+        import_list = list(imports)
+        assert len(import_list) == 1
+        assert ("os", 2) in import_list
+
+    def test_class_level_import_ignored(self):
+        """Test that imports inside classes are ignored."""
+        code = """
+import os
+
+class Foo:
+    import numpy
+"""
+        tree = ast.parse(code)
+        imports = extract_top_level_imports(tree)
+        import_list = list(imports)
+        assert len(import_list) == 1
+        assert ("os", 2) in import_list
+
+
+class TestBuildStdlibIndex:
+    """Test the build_stdlib_index function."""
+
+    def test_contains_common_modules(self):
+        """Test that stdlib index contains common modules."""
+        stdlib = build_stdlib_index()
+        assert "os" in stdlib
+        assert "sys" in stdlib
+        assert "json" in stdlib
+        assert "pathlib" in stdlib
+
+    def test_cached(self):
+        """Test that function is cached."""
+        result1 = build_stdlib_index()
+        result2 = build_stdlib_index()
+        assert result1 is result2
+
+
+class TestCheckImports:
+    """Test the check_imports function."""
+
+    def test_stdlib_imports_pass(self):
+        """Test that stdlib imports pass validation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("import os\nimport sys\nfrom pathlib import Path\n")
+            file_path = Path(f.name)
+
+        try:
+            config = ImportGuardConfig()
+            result = check_imports([file_path], config, quiet=True)
+            assert result == 0
+        finally:
+            file_path.unlink()
+
+    def test_third_party_imports_fail(self):
+        """Test that third-party imports fail validation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("import pandas\nimport numpy\n")
+            file_path = Path(f.name)
+
+        try:
+            config = ImportGuardConfig()
+            result = check_imports([file_path], config, quiet=True)
+            assert result == 1
+        finally:
+            file_path.unlink()
+
+    def test_allowed_modules_pass(self):
+        """Test that allowed modules pass validation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("import pandas\nimport numpy\n")
+            file_path = Path(f.name)
+
+        try:
+            config = ImportGuardConfig(module_allowlist=["pandas", "numpy"])
+            result = check_imports([file_path], config, quiet=True)
+            assert result == 0
+        finally:
+            file_path.unlink()
+
+    def test_function_level_imports_pass(self):
+        """Test that function-level third-party imports pass."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("""
+import os
+
+def foo():
+    import pandas
+    return pandas.DataFrame()
+""")
+            file_path = Path(f.name)
+
+        try:
+            config = ImportGuardConfig()
+            result = check_imports([file_path], config, quiet=True)
+            assert result == 0
+        finally:
+            file_path.unlink()
+
+    def test_syntax_error_fails(self):
+        """Test that syntax errors are reported."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("import os\nthis is not valid python\n")
+            file_path = Path(f.name)
+
+        try:
+            config = ImportGuardConfig()
+            result = check_imports([file_path], config, quiet=True)
+            assert result == 1
+        finally:
+            file_path.unlink()
+
+    def test_empty_file_passes(self):
+        """Test that empty files pass validation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            file_path = Path(f.name)
+
+        try:
+            config = ImportGuardConfig()
+            result = check_imports([file_path], config, quiet=True)
+            assert result == 0
+        finally:
+            file_path.unlink()
+
+    def test_path_scoped_allowlist(self):
+        """Test path-scoped allowlists work correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir).resolve()
+            test_file = tmpdir_path / "test.py"
+            test_file.write_text("import pytest\n")
+
+            config = ImportGuardConfig(
+                path_scoped_allowlist={
+                    str(tmpdir_path): ["pytest"],
+                }
+            )
+            result = check_imports([test_file], config, quiet=True)
+            assert result == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/.github/scripts/conftest.py
+++ b/.github/scripts/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration for CI scripts."""
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent.resolve()
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/.github/scripts/package_imports/package_imports.py
+++ b/.github/scripts/package_imports/package_imports.py
@@ -1,63 +1,64 @@
 #!/usr/bin/env python3
-"""
-Test that installed packages can be imported successfully.
+"""Test that installed packages can be imported successfully.
 
 This script verifies that all expected modules from the kfp-components
 package can be imported using the kfp_components namespace.
 """
 
 import argparse
-import sys
 import importlib
+import sys
 
 
 def test_imports() -> bool:
     """Test package imports for the single catalog package."""
     success = True
-    
+
     print("Testing package imports...")
     print(f"Python path: {sys.path}")
-    
+
     # Test main modules
     try:
-        import kfp_components  # type: ignore[import-not-found]
-        from kfp_components import components, pipelines  # type: ignore[import-not-found]
+        import kfp_components  # type: ignore[import-not-found]  # noqa: F401
+        from kfp_components import components, pipelines  # type: ignore[import-not-found]  # noqa: F401
+
         print("✓ Main modules imported successfully")
     except ImportError as e:
         print(f"✗ Failed to import main modules: {e}")
         success = False
         return success
-    
+
     # Test category imports
-    categories = ['training', 'evaluation', 'data_processing', 'deployment']
-    
+    categories = ["training", "evaluation", "data_processing", "deployment"]
+
     for category in categories:
         comp_module = f"kfp_components.components.{category}"
         pipe_module = f"kfp_components.pipelines.{category}"
-            
+
         try:
             importlib.import_module(comp_module)
             print(f"✓ {comp_module} imported successfully")
         except ImportError as e:
             print(f"✗ Failed to import {comp_module}: {e}")
             success = False
-        
+
         try:
             importlib.import_module(pipe_module)
             print(f"✓ {pipe_module} imported successfully")
         except ImportError as e:
             print(f"✗ Failed to import {pipe_module}: {e}")
             success = False
-    
+
     if success:
         print("\nAll package imports successful!")
     else:
         print("\nSome package imports failed")
-    
+
     return success
 
 
 def main():
+    """Main entry point for testing package imports."""
     argparse.ArgumentParser(description="Test package imports for Kubeflow Pipelines components").parse_args()
     success = test_imports()
     sys.exit(0 if success else 1)
@@ -65,4 +66,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,3 +1,4 @@
+---
 name: Build and Test Python Packages
 
 on:
@@ -53,7 +54,7 @@ jobs:
         run: |
           echo "Installing package..."
           uv pip install --python test-env dist/*.whl
-          
+
           echo "Testing package imports..."
           test-env/bin/python .github/scripts/package_imports/package_imports.py
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,44 @@
+---
+name: Markdown Lint
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  markdown-lint:
+    name: markdown-lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli@0.39.0
+
+      - name: Determine changed Markdown files
+        id: changed-markdown
+        uses: ./.github/actions/detect-changed-assets
+        with:
+          filter: '\.md$'
+
+      - name: Run markdownlint (changed files)
+        if: steps.changed-markdown.outputs.filtered-changed-files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed-markdown.outputs.filtered-changed-files }}
+        run: |
+          markdownlint -c .markdownlint.json -- $CHANGED_FILES

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,64 @@
+---
+name: Python Lint
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  python-lint:
+    name: python-lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python & deps
+        uses: ./.github/actions/setup-python-ci
+        with:
+          python-version: "3.11"
+          extra: lint
+
+      - name: Determine changed Python files
+        id: changed-python
+        uses: ./.github/actions/detect-changed-assets
+        with:
+          filter: '\.py$'
+
+      - name: Run ruff format check (changed files)
+        if: steps.changed-python.outputs.filtered-changed-files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed-python.outputs.filtered-changed-files }}
+        run: |
+          uv run ruff format --check $CHANGED_FILES
+
+      - name: Run ruff lint (changed files)
+        if: steps.changed-python.outputs.filtered-changed-files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed-python.outputs.filtered-changed-files }}
+        run: |
+          uv run ruff check $CHANGED_FILES
+
+      - name: Determine changed components/pipelines Python files
+        id: changed-components-pipelines
+        uses: ./.github/actions/detect-changed-assets
+        with:
+          filter: '^(components|pipelines)/.*\.py$'
+
+      - name: Run custom import guard
+        if: steps.changed-components-pipelines.outputs.filtered-changed-files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed-components-pipelines.outputs.filtered-changed-files }}
+        run: |
+          uv run python .github/scripts/check_imports/check_imports.py \
+            --config .github/scripts/check_imports/import_exceptions.yaml \
+            -- $CHANGED_FILES

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,42 @@
+---
+name: YAML Lint
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  yaml-lint:
+    name: yaml-lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python & deps
+        uses: ./.github/actions/setup-python-ci
+        with:
+          python-version: "3.11"
+          extra: lint
+
+      - name: Determine changed YAML files
+        id: changed-yaml
+        uses: ./.github/actions/detect-changed-assets
+        with:
+          filter: '\.(yml|yaml)$'
+
+      - name: Run yamllint (changed files)
+        if: steps.changed-yaml.outputs.filtered-changed-files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed-yaml.outputs.filtered-changed-files }}
+        run: |
+          uv run yamllint -c .yamllint.yml -- $CHANGED_FILES

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 120,
+    "heading_line_length": 120,
+    "code_block_line_length": 160
+  },
+  "MD033": false,
+  "MD041": false
+}
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+---
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types: [python]
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check
+        language: system
+        types: [python]
+      - id: yamllint
+        name: yamllint
+        entry: uv run yamllint -c .yamllint.yml
+        language: system
+        types: [yaml]
+      - id: import-guard
+        name: import-guard
+        entry: >
+          uv run python .github/scripts/check_imports/check_imports.py
+          --config .github/scripts/check_imports/import_exceptions.yaml
+        language: system
+        types: [python]
+        files: ^(components|pipelines)/
+      - id: markdownlint
+        name: markdownlint
+        entry: npx markdownlint-cli@0.39.0 -c .markdownlint.json
+        language: system
+        types: [markdown]

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,10 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 120
+    level: warning
+  truthy:
+    level: warning
+    ignore: |
+      .github/workflows

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+RUFF ?= uv run ruff
+MARKDOWNLINT ?= markdownlint
+YAMLLINT ?= uv run yamllint
+PYTHON ?= uv run python
+PYTEST ?= uv run pytest
+
+.PHONY: format fix lint lint-format lint-python lint-markdown lint-yaml lint-imports test test-coverage
+
+format:
+	$(RUFF) format components pipelines scripts
+	$(RUFF) check --fix components pipelines scripts
+
+fix: format
+	@echo "Auto-fixing Python formatting and lint issues..."
+	@echo "Note: Markdown and YAML issues may need manual fixes"
+
+lint: lint-format lint-python lint-markdown lint-yaml lint-imports
+
+lint-format:
+	$(RUFF) format --check components pipelines scripts
+
+lint-python:
+	$(RUFF) check components pipelines scripts
+
+lint-markdown:
+	$(MARKDOWNLINT) -c .markdownlint.json .
+
+lint-yaml:
+	$(YAMLLINT) -c .yamllint.yml .
+
+lint-imports:
+	$(PYTHON) .github/scripts/check_imports/check_imports.py --config .github/scripts/check_imports/import_exceptions.yaml components pipelines
+
+test:
+	cd .github/scripts && $(PYTEST) */tests/ -v $(ARGS)
+
+test-coverage:
+	cd .github/scripts && $(PYTEST) */tests/ --cov=. --cov-report=term-missing -v $(ARGS)
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,12 +19,16 @@ Welcome! This guide covers everything you need to know to contribute components 
 Before contributing, ensure you have the following tools installed:
 
 - **Python 3.11+** for component development
-- **uv** ([installation guide](https://docs.astral.sh/uv/getting-started/installation)) to manage Python dependencies including `kfp` and `kfp-kubernetes` packages
-- **pre-commit** ([installation guide](https://pre-commit.com/#installation)) for automated code quality checks
+- **uv** ([installation guide](https://docs.astral.sh/uv/getting-started/installation)) to manage
+  Python dependencies including `kfp` and `kfp-kubernetes` packages
+- **pre-commit** ([installation guide](https://pre-commit.com/#installation)) for automated code
+  quality checks
 - **Docker or Podman** to build container images for custom components
-- **kubectl** ([installation guide](https://kubernetes.io/docs/tasks/tools/)) for Kubernetes operations
+- **kubectl** ([installation guide](https://kubernetes.io/docs/tasks/tools/)) for Kubernetes
+  operations
 
-All contributors must follow the [Kubeflow Community Code of Conduct](https://github.com/kubeflow/community/blob/master/CODE_OF_CONDUCT.md).
+All contributors must follow the
+[Kubeflow Community Code of Conduct](https://github.com/kubeflow/community/blob/master/CODE_OF_CONDUCT.md).
 
 ## Quick Setup
 
@@ -55,8 +59,6 @@ uv venv
 source .venv/bin/activate
 uv sync          # Installs package in editable mode
 uv sync --dev    # Include dev dependencies if defined
-
-# Install pre-commit hooks for automatic code quality checks
 pre-commit install
 
 # Verify your setup works
@@ -98,7 +100,8 @@ Pipelines must be organized by category under `pipelines/<category>/`.
 ## Naming Conventions
 
 - **Components and pipelines** use `snake_case` (e.g., `data_preprocessing`, `model_trainer`)
-- **Commit messages** follow [Conventional Commits](https://conventionalcommits.org/) format with type prefix (feat, fix, docs, etc.)
+- **Commit messages** follow [Conventional Commits](https://conventionalcommits.org/) format with
+  type prefix (feat, fix, docs, etc.)
 
 ### Required Files
 
@@ -162,7 +165,8 @@ links:  # Optional, can use custom key-value (not limited to documentation, issu
 
 ### OWNERS File
 
-The OWNERS file enables component owners to self-service maintenance tasks including approvals, metadata updates, and lifecycle management:
+The OWNERS file enables component owners to self-service maintenance tasks including approvals,
+metadata updates, and lifecycle management:
 
 ```yaml
 approvers:
@@ -174,11 +178,15 @@ reviewers:
 
 The `OWNERS` file enables code review automation by leveraging PROW commands:
 
-- **Reviewers** (as well as **Approvers**), upon reviewing a PR and finding it good to merge, can comment `/lgtm`, which applies the `lgtm` label to the PR
-- **Approvers** (but not **Reviewers**) can comment `/approve`, which signifies the PR is approved for automation to merge into the repo.
-- If a PR has been labeled with both `lgtm` and `approve`, and all required CI checks are passing, PROW will merge the PR into the destination branch.
+- **Reviewers** (as well as **Approvers**), upon reviewing a PR and finding it good to merge, can
+  comment `/lgtm`, which applies the `lgtm` label to the PR
+- **Approvers** (but not **Reviewers**) can comment `/approve`, which signifies the PR is approved
+  for automation to merge into the repo.
+- If a PR has been labeled with both `lgtm` and `approve`, and all required CI checks are passing,
+  PROW will merge the PR into the destination branch.
 
-See [full Prow documentation](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#lgtm-label) for usage details.
+See [full Prow documentation](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#lgtm-label)
+for usage details.
 
 ## Development Workflow
 
@@ -236,7 +244,8 @@ def test_hello_world_custom_name():
 
 ### 3. Document Your Component
 
-This repository requires a standardized README.md. As such, we have provided a README generation utility, which can be found in the `scripts` directory.
+This repository requires a standardized README.md. As such, we have provided a README generation
+utility, which can be found in the `scripts` directory.
 
 Read more in the [README Generator Script Documentation](./scripts/generate_readme/README.md).
 
@@ -259,11 +268,24 @@ pytest tests/test_my_component.py -v
 Ensure your code meets quality standards:
 
 ```bash
-# Format checking (120 character line length)
-black --check --line-length 120 .
+# Format and lint with ruff
+uv run ruff format --check .      # Check formatting (120 char line length)
+uv run ruff check .                # Check linting, docstrings, and import order
 
-# Docstring validation (Google convention)
-pydocstyle --convention=google .
+# Or use make commands for convenience
+make lint                          # Run all linting checks
+make format                        # Auto-format and auto-fix issues
+
+# Validate import guard (enforces stdlib-only top-level imports)
+uv run python .github/scripts/check_imports/check_imports.py \
+  --config .github/scripts/check_imports/import_exceptions.yaml \
+  components pipelines
+
+# Validate YAML files
+uv run yamllint -c .yamllint.yml .
+
+# Validate Markdown files
+markdownlint -c .markdownlint.json **/*.md
 
 # Validate metadata schema
 python scripts/validate_metadata.py
@@ -274,7 +296,8 @@ pre-commit run --all-files
 
 ### Base Image Validation
 
-All components and pipelines must use approved base images. The validation script compiles components using `kfp.compiler` to extract the actual runtime images, which correctly handles:
+All components and pipelines must use approved base images. The validation script compiles components
+using `kfp.compiler` to extract the actual runtime images, which correctly handles:
 
 - Variable references (`base_image=MY_IMAGE`)
 - `functools.partial` wrappers
@@ -292,7 +315,14 @@ Run the validation locally:
 uv run python scripts/validate_base_images/validate_base_images.py
 ```
 
-The script allows any standard Python image matching `python:<version>` (e.g., `python:3.11`, `python:3.10-slim`) in addition to Kubeflow registry images.
+The script allows any standard Python image matching `python:<version>` (e.g., `python:3.11`,
+`python:3.10-slim`) in addition to Kubeflow registry images.
+
+**Import Guard**: This repository enforces that top-level imports must be limited to Python's
+standard library. Heavy dependencies (like `kfp`, `pandas`, etc.) should be imported within
+function/pipeline bodies. Exceptions can be added to
+`.github/scripts/check_imports/import_exceptions.yaml` when justified (e.g., for test files
+importing `pytest`).
 
 ### Building Custom Container Images
 
@@ -310,7 +340,10 @@ docker run --rm my-component:test echo "Hello, world!"
 
 GitHub Actions automatically runs these checks on every pull request:
 
-- Code formatting (Black), linting (Flake8), docstring validation (pydocstyle), type checking (MyPy)
+- **Python linting**: Code formatting, style checks, docstring validation, and import sorting
+- **Import guard**: Validates that top-level imports are limited to Python's standard library
+- **YAML linting**: Validates YAML file syntax and style (yamllint)
+- **Markdown linting**: Validates Markdown formatting and style (markdownlint)
 - Unit and integration tests with coverage reporting
 - Container image builds for components with Containerfiles
 - Security vulnerability scans
@@ -361,16 +394,20 @@ All pull requests must complete the following:
   - Component works as described
   - Code is clean and well-documented
   - Included tests provide good coverage.
-- Receive approval from component OWNERS (for updates to existing components) or repository maintainers (for new components)
+- Receive approval from component OWNERS (for updates to existing components) or repository
+  maintainers (for new components)
 
 ## Getting Help
 
 - **Governance questions**: See [GOVERNANCE.md](GOVERNANCE.md) for ownership, verification, and process details
-- **Community discussion**: Join `#kubeflow-pipelines` channel on the [CNCF Slack](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
-- **Bug reports and feature requests**: Open an issue at [GitHub Issues](https://github.com/kubeflow/pipelines-components/issues)
+- **Community discussion**: Join `#kubeflow-pipelines` channel on the
+  [CNCF Slack](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
+- **Bug reports and feature requests**: Open an issue at
+  [GitHub Issues](https://github.com/kubeflow/pipelines-components/issues)
 
 ---
 
-This repository was established through [KEP-913: Components Repository](https://github.com/kubeflow/community/tree/master/proposals/913-components-repo).
+This repository was established through
+[KEP-913: Components Repository](https://github.com/kubeflow/community/tree/master/proposals/913-components-repo).
 
 Thanks for contributing to Kubeflow! 🚀

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -19,9 +19,11 @@ This document defines the governance structure for the Kubeflow Pipelines compon
 
 ### KFP Components Repository Maintainer
 
-Repository Maintainers steward the Kubeflow Pipelines Components repository. They are listed in the root `OWNERS` file under `approvers`.
+Repository Maintainers steward the Kubeflow Pipelines Components repository. They are listed in
+the root `OWNERS` file under `approvers`.
 
 Responsibilities:
+
 - Orchestrate releases
 - Set roadmaps and accept KEPs related to Kubeflow Pipelines Components
 - Manage overall project health and issue triage
@@ -29,9 +31,11 @@ Responsibilities:
 
 ### Component or Pipeline Owner
 
-Owners are listed as `approvers` in an asset’s `OWNERS` file. Every asset must have at least one owner to ensure accountability and continuity. Approvers must be Kubeflow community members.
+Owners are listed as `approvers` in an asset's `OWNERS` file. Every asset must have at least one
+owner to ensure accountability and continuity. Approvers must be Kubeflow community members.
 
 Responsibilities:
+
 - Act as the main point of contact for their asset(s)
 - Review and approve changes to their asset(s)
 - Keep metadata, documentation, and verification fresh
@@ -41,13 +45,16 @@ Responsibilities:
 
 - **Owned by**: Kubeflow community
 - **Maintained by**: Asset owners listed in each `OWNERS` file
-- **Support**: Officially part of the single catalog; support expectations come from the verification SLA and CI requirements
+- **Support**: Officially part of the single catalog; support expectations come from the
+  verification SLA and CI requirements
 
 ## Verification and Removal
 
 - Assets must keep `lastVerified` fresh (within 12 months) and pass CI.
-- At ~9 months without verification, automation/open issues should prompt owners to refresh metadata and validation.
-- At 12 months without verification or for unresolved compatibility/security issues, Repository Maintainers may remove the asset from the catalog.
+- At ~9 months without verification, automation/open issues should prompt owners to refresh
+  metadata and validation.
+- At 12 months without verification or for unresolved compatibility/security issues, Repository
+  Maintainers may remove the asset from the catalog.
 - Emergency removal may occur for critical security, legal, or malicious code issues.
 
 ## Deprecation Policy
@@ -63,11 +70,13 @@ Responsibilities:
 *Framework for making technical, policy, and strategic decisions within the community.*
 
 ### Decision Types
+
 - **Technical (asset-level)**: Asset owners, with escalation to Repository Maintainers if needed
 - **Policy**: Repository Maintainers
 - **Strategic**: Repository Maintainers
 
 ### Process
+
 1. **Proposal**: Create a GitHub issue or RFC
 2. **Discussion**: Community feedback
 3. **Decision**: Appropriate authority level
@@ -76,19 +85,22 @@ Responsibilities:
 ## Policy Updates
 
 **Process:**
+
 1. **RFC/Issue**: Propose changes via GitHub issue
 2. **Community review**: 2-week feedback period where practical
 3. **Maintainer approval**: Majority of Repository Maintainers
 4. **Implementation**: Update documentation and automation
 
 **Criteria for updates:**
+
 - Community needs and process improvements
 - Conflict resolution learnings
 - External requirements and security posture
 
 ---
 
-This governance model ensures quality, sustainability, and community collaboration while keeping a single, consistent catalog.
+This governance model ensures quality, sustainability, and community collaboration while keeping
+a single, consistent catalog.
 
 ## Related Documentation
 
@@ -98,6 +110,9 @@ This governance model ensures quality, sustainability, and community collaborati
 
 ## Background
 
-Based on [KEP-913: Components Repository](https://github.com/kubeflow/community/tree/master/proposals/913-components-repo), establishing a curated catalog of reusable Kubeflow Pipelines assets with clear quality standards and community governance.
+Based on
+[KEP-913: Components Repository](https://github.com/kubeflow/community/tree/master/proposals/913-components-repo),
+establishing a curated catalog of reusable Kubeflow Pipelines assets with clear quality standards
+and community governance.
 
 For questions about governance, contact the Repository Maintainers (root `OWNERS`) or open a GitHub issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# CI
+lint = [
+  "ruff==0.8.4",
+  "yamllint==1.35.1",
+]
+test = [
+  "pytest>=8.0.0",
+  "pytest-cov>=4.1.0",
+]
 ci = [
     "pytest",
     "docstring-parser",
@@ -27,7 +34,8 @@ ci = [
 # Local development (extends ci with additional tools)
 dev = [
     "kfp-components[ci]",
-    # Add linting/formatting tools here as needed:
+    "kfp-components[lint]",
+    "kfp-components[test]",
 ]
 
 [project.urls]
@@ -59,5 +67,47 @@ packages = [
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.yml", "*.json"]
 
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+exclude = [
+    ".git",
+    ".venv",
+    "build",
+    "dist",
+    "__pycache__",
+    "node_modules",
+    "**/_generated/",
+]
+
+[tool.ruff.lint]
+# Enable pycodestyle (E, W), pyflakes (F), isort (I), pydocstyle (D)
+select = ["E", "W", "F", "I", "D"]
+ignore = [
+    "D100",  # Missing docstring in public module
+    "D104",  # Missing docstring in public package
+    "D415",  # First line should end with punctuation (not needed for simple module names)
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.isort]
+known-first-party = ["kubeflow"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+docstring-code-format = true
+
+# Pytest configuration for KEP-913 repository structure
+# Currently tests are in scripts/ only. When component/pipeline tests are added,
+# this configuration will need to be updated to handle tests in components/*/tests/
 [tool.pytest.ini_options]
-testpaths = ["scripts/generate_readme/tests"]
+testpaths = ["scripts"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+# Don't search these directories
+norecursedirs = [".git", ".venv", "build", "dist", "__pycache__", "components", "pipelines"]

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,98 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/26/4a96807b193b011588099c3b5c89fbb05294e5b90e71018e065465f34eb6/coverage-7.12.0.tar.gz", hash = "sha256:fc11e0a4e372cb5f282f16ef90d4a585034050ccda536451901abfb19a57f40c", size = 819341, upload-time = "2025-11-18T13:34:20.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/0c/0dfe7f0487477d96432e4815537263363fb6dd7289743a796e8e51eabdf2/coverage-7.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aa124a3683d2af98bd9d9c2bfa7a5076ca7e5ab09fdb96b81fa7d89376ae928f", size = 217535, upload-time = "2025-11-18T13:32:08.812Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f5/f9a4a053a5bbff023d3bec259faac8f11a1e5a6479c2ccf586f910d8dac7/coverage-7.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d93fbf446c31c0140208dcd07c5d882029832e8ed7891a39d6d44bd65f2316c3", size = 218044, upload-time = "2025-11-18T13:32:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c5/84fc3697c1fa10cd8571919bf9693f693b7373278daaf3b73e328d502bc8/coverage-7.12.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:52ca620260bd8cd6027317bdd8b8ba929be1d741764ee765b42c4d79a408601e", size = 248440, upload-time = "2025-11-18T13:32:12.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/36/2d93fbf6a04670f3874aed397d5a5371948a076e3249244a9e84fb0e02d6/coverage-7.12.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f3433ffd541380f3a0e423cff0f4926d55b0cc8c1d160fdc3be24a4c03aa65f7", size = 250361, upload-time = "2025-11-18T13:32:13.852Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/49/66dc65cc456a6bfc41ea3d0758c4afeaa4068a2b2931bf83be6894cf1058/coverage-7.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7bbb321d4adc9f65e402c677cd1c8e4c2d0105d3ce285b51b4d87f1d5db5245", size = 252472, upload-time = "2025-11-18T13:32:15.068Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1f/ebb8a18dffd406db9fcd4b3ae42254aedcaf612470e8712f12041325930f/coverage-7.12.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22a7aade354a72dff3b59c577bfd18d6945c61f97393bc5fb7bd293a4237024b", size = 248592, upload-time = "2025-11-18T13:32:16.328Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/67f213c06e5ea3b3d4980df7dc344d7fea88240b5fe878a5dcbdfe0e2315/coverage-7.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3ff651dcd36d2fea66877cd4a82de478004c59b849945446acb5baf9379a1b64", size = 250167, upload-time = "2025-11-18T13:32:17.687Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/e52aef68154164ea40cc8389c120c314c747fe63a04b013a5782e989b77f/coverage-7.12.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:31b8b2e38391a56e3cea39d22a23faaa7c3fc911751756ef6d2621d2a9daf742", size = 248238, upload-time = "2025-11-18T13:32:19.2Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a4/4d88750bcf9d6d66f77865e5a05a20e14db44074c25fd22519777cb69025/coverage-7.12.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:297bc2da28440f5ae51c845a47c8175a4db0553a53827886e4fb25c66633000c", size = 247964, upload-time = "2025-11-18T13:32:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/b74693158899d5b47b0bf6238d2c6722e20ba749f86b74454fac0696bb00/coverage-7.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ff7651cc01a246908eac162a6a86fc0dbab6de1ad165dfb9a1e2ec660b44984", size = 248862, upload-time = "2025-11-18T13:32:22.304Z" },
+    { url = "https://files.pythonhosted.org/packages/18/de/6af6730227ce0e8ade307b1cc4a08e7f51b419a78d02083a86c04ccceb29/coverage-7.12.0-cp311-cp311-win32.whl", hash = "sha256:313672140638b6ddb2c6455ddeda41c6a0b208298034544cfca138978c6baed6", size = 220033, upload-time = "2025-11-18T13:32:23.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/e7f63021a7c4fe20994359fcdeae43cbef4a4d0ca36a5a1639feeea5d9e1/coverage-7.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1783ed5bd0d5938d4435014626568dc7f93e3cb99bc59188cc18857c47aa3c4", size = 220966, upload-time = "2025-11-18T13:32:25.599Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e8/deae26453f37c20c3aa0c4433a1e32cdc169bf415cce223a693117aa3ddd/coverage-7.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:4648158fd8dd9381b5847622df1c90ff314efbfc1df4550092ab6013c238a5fc", size = 219637, upload-time = "2025-11-18T13:32:27.265Z" },
+    { url = "https://files.pythonhosted.org/packages/02/bf/638c0427c0f0d47638242e2438127f3c8ee3cfc06c7fdeb16778ed47f836/coverage-7.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:29644c928772c78512b48e14156b81255000dcfd4817574ff69def189bcb3647", size = 217704, upload-time = "2025-11-18T13:32:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e1/706fae6692a66c2d6b871a608bbde0da6281903fa0e9f53a39ed441da36a/coverage-7.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8638cbb002eaa5d7c8d04da667813ce1067080b9a91099801a0053086e52b736", size = 218064, upload-time = "2025-11-18T13:32:30.161Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8b/eb0231d0540f8af3ffda39720ff43cb91926489d01524e68f60e961366e4/coverage-7.12.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:083631eeff5eb9992c923e14b810a179798bb598e6a0dd60586819fc23be6e60", size = 249560, upload-time = "2025-11-18T13:32:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/67fb52af642e974d159b5b379e4d4c59d0ebe1288677fbd04bbffe665a82/coverage-7.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:99d5415c73ca12d558e07776bd957c4222c687b9f1d26fa0e1b57e3598bdcde8", size = 252318, upload-time = "2025-11-18T13:32:33.178Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e5/38228f31b2c7665ebf9bdfdddd7a184d56450755c7e43ac721c11a4b8dab/coverage-7.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e949ebf60c717c3df63adb4a1a366c096c8d7fd8472608cd09359e1bd48ef59f", size = 253403, upload-time = "2025-11-18T13:32:34.45Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4b/df78e4c8188f9960684267c5a4897836f3f0f20a20c51606ee778a1d9749/coverage-7.12.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d907ddccbca819afa2cd014bc69983b146cca2735a0b1e6259b2a6c10be1e70", size = 249984, upload-time = "2025-11-18T13:32:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/bb163933d195a345c6f63eab9e55743413d064c291b6220df754075c2769/coverage-7.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b1518ecbad4e6173f4c6e6c4a46e49555ea5679bf3feda5edb1b935c7c44e8a0", size = 251339, upload-time = "2025-11-18T13:32:37.352Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/c9b29cdb8412c837cdcbc2cfa054547dd83affe6cbbd4ce4fdb92b6ba7d1/coverage-7.12.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51777647a749abdf6f6fd8c7cffab12de68ab93aab15efc72fbbb83036c2a068", size = 249489, upload-time = "2025-11-18T13:32:39.212Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/da/b3131e20ba07a0de4437a50ef3b47840dfabf9293675b0cd5c2c7f66dd61/coverage-7.12.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:42435d46d6461a3b305cdfcad7cdd3248787771f53fe18305548cba474e6523b", size = 249070, upload-time = "2025-11-18T13:32:40.598Z" },
+    { url = "https://files.pythonhosted.org/packages/70/81/b653329b5f6302c08d683ceff6785bc60a34be9ae92a5c7b63ee7ee7acec/coverage-7.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5bcead88c8423e1855e64b8057d0544e33e4080b95b240c2a355334bb7ced937", size = 250929, upload-time = "2025-11-18T13:32:42.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/250ac3bca9f252a5fb1338b5ad01331ebb7b40223f72bef5b1b2cb03aa64/coverage-7.12.0-cp312-cp312-win32.whl", hash = "sha256:dcbb630ab034e86d2a0f79aefd2be07e583202f41e037602d438c80044957baa", size = 220241, upload-time = "2025-11-18T13:32:44.665Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1c/77e79e76d37ce83302f6c21980b45e09f8aa4551965213a10e62d71ce0ab/coverage-7.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:2fd8354ed5d69775ac42986a691fbf68b4084278710cee9d7c3eaa0c28fa982a", size = 221051, upload-time = "2025-11-18T13:32:46.008Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f5/641b8a25baae564f9e52cac0e2667b123de961985709a004e287ee7663cc/coverage-7.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:737c3814903be30695b2de20d22bcc5428fdae305c61ba44cdc8b3252984c49c", size = 219692, upload-time = "2025-11-18T13:32:47.372Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/14/771700b4048774e48d2c54ed0c674273702713c9ee7acdfede40c2666747/coverage-7.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47324fffca8d8eae7e185b5bb20c14645f23350f870c1649003618ea91a78941", size = 217725, upload-time = "2025-11-18T13:32:49.22Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a7/3aa4144d3bcb719bf67b22d2d51c2d577bf801498c13cb08f64173e80497/coverage-7.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ccf3b2ede91decd2fb53ec73c1f949c3e034129d1e0b07798ff1d02ea0c8fa4a", size = 218098, upload-time = "2025-11-18T13:32:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9c/b846bbc774ff81091a12a10203e70562c91ae71badda00c5ae5b613527b1/coverage-7.12.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b365adc70a6936c6b0582dc38746b33b2454148c02349345412c6e743efb646d", size = 249093, upload-time = "2025-11-18T13:32:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b6/67d7c0e1f400b32c883e9342de4a8c2ae7c1a0b57c5de87622b7262e2309/coverage-7.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bc13baf85cd8a4cfcf4a35c7bc9d795837ad809775f782f697bf630b7e200211", size = 251686, upload-time = "2025-11-18T13:32:54.862Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/75/b095bd4b39d49c3be4bffbb3135fea18a99a431c52dd7513637c0762fecb/coverage-7.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:099d11698385d572ceafb3288a5b80fe1fc58bf665b3f9d362389de488361d3d", size = 252930, upload-time = "2025-11-18T13:32:56.417Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f3/466f63015c7c80550bead3093aacabf5380c1220a2a93c35d374cae8f762/coverage-7.12.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:473dc45d69694069adb7680c405fb1e81f60b2aff42c81e2f2c3feaf544d878c", size = 249296, upload-time = "2025-11-18T13:32:58.074Z" },
+    { url = "https://files.pythonhosted.org/packages/27/86/eba2209bf2b7e28c68698fc13437519a295b2d228ba9e0ec91673e09fa92/coverage-7.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:583f9adbefd278e9de33c33d6846aa8f5d164fa49b47144180a0e037f0688bb9", size = 251068, upload-time = "2025-11-18T13:32:59.646Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/55/ca8ae7dbba962a3351f18940b359b94c6bafdd7757945fdc79ec9e452dc7/coverage-7.12.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b2089cc445f2dc0af6f801f0d1355c025b76c24481935303cf1af28f636688f0", size = 249034, upload-time = "2025-11-18T13:33:01.481Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d7/39136149325cad92d420b023b5fd900dabdd1c3a0d1d5f148ef4a8cedef5/coverage-7.12.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:950411f1eb5d579999c5f66c62a40961f126fc71e5e14419f004471957b51508", size = 248853, upload-time = "2025-11-18T13:33:02.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/b6/76e1add8b87ef60e00643b0b7f8f7bb73d4bf5249a3be19ebefc5793dd25/coverage-7.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b1aab7302a87bafebfe76b12af681b56ff446dc6f32ed178ff9c092ca776e6bc", size = 250619, upload-time = "2025-11-18T13:33:04.336Z" },
+    { url = "https://files.pythonhosted.org/packages/95/87/924c6dc64f9203f7a3c1832a6a0eee5a8335dbe5f1bdadcc278d6f1b4d74/coverage-7.12.0-cp313-cp313-win32.whl", hash = "sha256:d7e0d0303c13b54db495eb636bc2465b2fb8475d4c8bcec8fe4b5ca454dfbae8", size = 220261, upload-time = "2025-11-18T13:33:06.493Z" },
+    { url = "https://files.pythonhosted.org/packages/91/77/dd4aff9af16ff776bf355a24d87eeb48fc6acde54c907cc1ea89b14a8804/coverage-7.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:ce61969812d6a98a981d147d9ac583a36ac7db7766f2e64a9d4d059c2fe29d07", size = 221072, upload-time = "2025-11-18T13:33:07.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/49/5c9dc46205fef31b1b226a6e16513193715290584317fd4df91cdaf28b22/coverage-7.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:bcec6f47e4cb8a4c2dc91ce507f6eefc6a1b10f58df32cdc61dff65455031dfc", size = 219702, upload-time = "2025-11-18T13:33:09.631Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/62/f87922641c7198667994dd472a91e1d9b829c95d6c29529ceb52132436ad/coverage-7.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:459443346509476170d553035e4a3eed7b860f4fe5242f02de1010501956ce87", size = 218420, upload-time = "2025-11-18T13:33:11.153Z" },
+    { url = "https://files.pythonhosted.org/packages/85/dd/1cc13b2395ef15dbb27d7370a2509b4aee77890a464fb35d72d428f84871/coverage-7.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:04a79245ab2b7a61688958f7a855275997134bc84f4a03bc240cf64ff132abf6", size = 218773, upload-time = "2025-11-18T13:33:12.569Z" },
+    { url = "https://files.pythonhosted.org/packages/74/40/35773cc4bb1e9d4658d4fb669eb4195b3151bef3bbd6f866aba5cd5dac82/coverage-7.12.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09a86acaaa8455f13d6a99221d9654df249b33937b4e212b4e5a822065f12aa7", size = 260078, upload-time = "2025-11-18T13:33:14.037Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ee/231bb1a6ffc2905e396557585ebc6bdc559e7c66708376d245a1f1d330fc/coverage-7.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:907e0df1b71ba77463687a74149c6122c3f6aac56c2510a5d906b2f368208560", size = 262144, upload-time = "2025-11-18T13:33:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/28/be/32f4aa9f3bf0b56f3971001b56508352c7753915345d45fab4296a986f01/coverage-7.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b57e2d0ddd5f0582bae5437c04ee71c46cd908e7bc5d4d0391f9a41e812dd12", size = 264574, upload-time = "2025-11-18T13:33:17.354Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7c/00489fcbc2245d13ab12189b977e0cf06ff3351cb98bc6beba8bd68c5902/coverage-7.12.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:58c1c6aa677f3a1411fe6fb28ec3a942e4f665df036a3608816e0847fad23296", size = 259298, upload-time = "2025-11-18T13:33:18.958Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b4/f0760d65d56c3bea95b449e02570d4abd2549dc784bf39a2d4721a2d8ceb/coverage-7.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4c589361263ab2953e3c4cd2a94db94c4ad4a8e572776ecfbad2389c626e4507", size = 262150, upload-time = "2025-11-18T13:33:20.644Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/9a9314df00f9326d78c1e5a910f520d599205907432d90d1c1b7a97aa4b1/coverage-7.12.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:91b810a163ccad2e43b1faa11d70d3cf4b6f3d83f9fd5f2df82a32d47b648e0d", size = 259763, upload-time = "2025-11-18T13:33:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/10/34/01a0aceed13fbdf925876b9a15d50862eb8845454301fe3cdd1df08b2182/coverage-7.12.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:40c867af715f22592e0d0fb533a33a71ec9e0f73a6945f722a0c85c8c1cbe3a2", size = 258653, upload-time = "2025-11-18T13:33:24.239Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/04/81d8fd64928acf1574bbb0181f66901c6c1c6279c8ccf5f84259d2c68ae9/coverage-7.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:68b0d0a2d84f333de875666259dadf28cc67858bc8fd8b3f1eae84d3c2bec455", size = 260856, upload-time = "2025-11-18T13:33:26.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/76/fa2a37bfaeaf1f766a2d2360a25a5297d4fb567098112f6517475eee120b/coverage-7.12.0-cp313-cp313t-win32.whl", hash = "sha256:73f9e7fbd51a221818fd11b7090eaa835a353ddd59c236c57b2199486b116c6d", size = 220936, upload-time = "2025-11-18T13:33:28.165Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/52/60f64d932d555102611c366afb0eb434b34266b1d9266fc2fe18ab641c47/coverage-7.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:24cff9d1f5743f67db7ba46ff284018a6e9aeb649b67aa1e70c396aa1b7cb23c", size = 222001, upload-time = "2025-11-18T13:33:29.656Z" },
+    { url = "https://files.pythonhosted.org/packages/77/df/c303164154a5a3aea7472bf323b7c857fed93b26618ed9fc5c2955566bb0/coverage-7.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c87395744f5c77c866d0f5a43d97cc39e17c7f1cb0115e54a2fe67ca75c5d14d", size = 220273, upload-time = "2025-11-18T13:33:31.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/fc12db0883478d6e12bbd62d481210f0c8daf036102aa11434a0c5755825/coverage-7.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a1c59b7dc169809a88b21a936eccf71c3895a78f5592051b1af8f4d59c2b4f92", size = 217777, upload-time = "2025-11-18T13:33:32.86Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c1/ce3e525d223350c6ec16b9be8a057623f54226ef7f4c2fee361ebb6a02b8/coverage-7.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8787b0f982e020adb732b9f051f3e49dd5054cebbc3f3432061278512a2b1360", size = 218100, upload-time = "2025-11-18T13:33:34.532Z" },
+    { url = "https://files.pythonhosted.org/packages/15/87/113757441504aee3808cb422990ed7c8bcc2d53a6779c66c5adef0942939/coverage-7.12.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ea5a9f7dc8877455b13dd1effd3202e0bca72f6f3ab09f9036b1bcf728f69ac", size = 249151, upload-time = "2025-11-18T13:33:36.135Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1d/9529d9bd44049b6b05bb319c03a3a7e4b0a8a802d28fa348ad407e10706d/coverage-7.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fdba9f15849534594f60b47c9a30bc70409b54947319a7c4fd0e8e3d8d2f355d", size = 251667, upload-time = "2025-11-18T13:33:37.996Z" },
+    { url = "https://files.pythonhosted.org/packages/11/bb/567e751c41e9c03dc29d3ce74b8c89a1e3396313e34f255a2a2e8b9ebb56/coverage-7.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a00594770eb715854fb1c57e0dea08cce6720cfbc531accdb9850d7c7770396c", size = 253003, upload-time = "2025-11-18T13:33:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b3/c2cce2d8526a02fb9e9ca14a263ca6fc074449b33a6afa4892838c903528/coverage-7.12.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5560c7e0d82b42eb1951e4f68f071f8017c824ebfd5a6ebe42c60ac16c6c2434", size = 249185, upload-time = "2025-11-18T13:33:42.086Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a7/967f93bb66e82c9113c66a8d0b65ecf72fc865adfba5a145f50c7af7e58d/coverage-7.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d6c2e26b481c9159c2773a37947a9718cfdc58893029cdfb177531793e375cfc", size = 251025, upload-time = "2025-11-18T13:33:43.634Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b2/f2f6f56337bc1af465d5b2dc1ee7ee2141b8b9272f3bf6213fcbc309a836/coverage-7.12.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6e1a8c066dabcde56d5d9fed6a66bc19a2883a3fe051f0c397a41fc42aedd4cc", size = 248979, upload-time = "2025-11-18T13:33:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7a/bf4209f45a4aec09d10a01a57313a46c0e0e8f4c55ff2965467d41a92036/coverage-7.12.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f7ba9da4726e446d8dd8aae5a6cd872511184a5d861de80a86ef970b5dacce3e", size = 248800, upload-time = "2025-11-18T13:33:47.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b7/1e01b8696fb0521810f60c5bbebf699100d6754183e6cc0679bf2ed76531/coverage-7.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e0f483ab4f749039894abaf80c2f9e7ed77bbf3c737517fb88c8e8e305896a17", size = 250460, upload-time = "2025-11-18T13:33:49.537Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ae/84324fb9cb46c024760e706353d9b771a81b398d117d8c1fe010391c186f/coverage-7.12.0-cp314-cp314-win32.whl", hash = "sha256:76336c19a9ef4a94b2f8dc79f8ac2da3f193f625bb5d6f51a328cd19bfc19933", size = 220533, upload-time = "2025-11-18T13:33:51.16Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/71/1033629deb8460a8f97f83e6ac4ca3b93952e2b6f826056684df8275e015/coverage-7.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7c1059b600aec6ef090721f8f633f60ed70afaffe8ecab85b59df748f24b31fe", size = 221348, upload-time = "2025-11-18T13:33:52.776Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5f/ac8107a902f623b0c251abdb749be282dc2ab61854a8a4fcf49e276fce2f/coverage-7.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:172cf3a34bfef42611963e2b661302a8931f44df31629e5b1050567d6b90287d", size = 219922, upload-time = "2025-11-18T13:33:54.316Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6e/f27af2d4da367f16077d21ef6fe796c874408219fa6dd3f3efe7751bd910/coverage-7.12.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:aa7d48520a32cb21c7a9b31f81799e8eaec7239db36c3b670be0fa2403828d1d", size = 218511, upload-time = "2025-11-18T13:33:56.343Z" },
+    { url = "https://files.pythonhosted.org/packages/67/dd/65fd874aa460c30da78f9d259400d8e6a4ef457d61ab052fd248f0050558/coverage-7.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:90d58ac63bc85e0fb919f14d09d6caa63f35a5512a2205284b7816cafd21bb03", size = 218771, upload-time = "2025-11-18T13:33:57.966Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e0/7c6b71d327d8068cb79c05f8f45bf1b6145f7a0de23bbebe63578fe5240a/coverage-7.12.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ca8ecfa283764fdda3eae1bdb6afe58bf78c2c3ec2b2edcb05a671f0bba7b3f9", size = 260151, upload-time = "2025-11-18T13:33:59.597Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ce/4697457d58285b7200de6b46d606ea71066c6e674571a946a6ea908fb588/coverage-7.12.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:874fe69a0785d96bd066059cd4368022cebbec1a8958f224f0016979183916e6", size = 262257, upload-time = "2025-11-18T13:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/33/acbc6e447aee4ceba88c15528dbe04a35fb4d67b59d393d2e0d6f1e242c1/coverage-7.12.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b3c889c0b8b283a24d721a9eabc8ccafcfc3aebf167e4cd0d0e23bf8ec4e339", size = 264671, upload-time = "2025-11-18T13:34:02.795Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/e2822a795c1ed44d569980097be839c5e734d4c0c1119ef8e0a073496a30/coverage-7.12.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8bb5b894b3ec09dcd6d3743229dc7f2c42ef7787dc40596ae04c0edda487371e", size = 259231, upload-time = "2025-11-18T13:34:04.397Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c5/a7ec5395bb4a49c9b7ad97e63f0c92f6bf4a9e006b1393555a02dae75f16/coverage-7.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:79a44421cd5fba96aa57b5e3b5a4d3274c449d4c622e8f76882d76635501fd13", size = 262137, upload-time = "2025-11-18T13:34:06.068Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0c/02c08858b764129f4ecb8e316684272972e60777ae986f3865b10940bdd6/coverage-7.12.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:33baadc0efd5c7294f436a632566ccc1f72c867f82833eb59820ee37dc811c6f", size = 259745, upload-time = "2025-11-18T13:34:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/04/4fd32b7084505f3829a8fe45c1a74a7a728cb251aaadbe3bec04abcef06d/coverage-7.12.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c406a71f544800ef7e9e0000af706b88465f3573ae8b8de37e5f96c59f689ad1", size = 258570, upload-time = "2025-11-18T13:34:09.676Z" },
+    { url = "https://files.pythonhosted.org/packages/48/35/2365e37c90df4f5342c4fa202223744119fe31264ee2924f09f074ea9b6d/coverage-7.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e71bba6a40883b00c6d571599b4627f50c360b3d0d02bfc658168936be74027b", size = 260899, upload-time = "2025-11-18T13:34:11.259Z" },
+    { url = "https://files.pythonhosted.org/packages/05/56/26ab0464ca733fa325e8e71455c58c1c374ce30f7c04cebb88eabb037b18/coverage-7.12.0-cp314-cp314t-win32.whl", hash = "sha256:9157a5e233c40ce6613dead4c131a006adfda70e557b6856b97aceed01b0e27a", size = 221313, upload-time = "2025-11-18T13:34:12.863Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1c/017a3e1113ed34d998b27d2c6dba08a9e7cb97d362f0ec988fcd873dcf81/coverage-7.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e84da3a0fd233aeec797b981c51af1cabac74f9bd67be42458365b30d11b5291", size = 222423, upload-time = "2025-11-18T13:34:15.14Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/bcc504fdd5169301b52568802bb1b9cdde2e27a01d39fbb3b4b508ab7c2c/coverage-7.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:01d24af36fedda51c2b1aca56e4330a3710f83b02a5ff3743a6b015ffa7c9384", size = 220459, upload-time = "2025-11-18T13:34:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a3/43b749004e3c09452e39bb56347a008f0a0668aad37324a99b5c8ca91d9e/coverage-7.12.0-py3-none-any.whl", hash = "sha256:159d50c0b12e060b15ed3d39f87ed43d4f7f7ad40b8a534f4dd331adbb51104a", size = 209503, upload-time = "2025-11-18T13:34:18.892Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -324,6 +416,18 @@ dev = [
     { name = "docstring-parser" },
     { name = "jinja2" },
     { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pyyaml" },
+    { name = "ruff" },
+    { name = "yamllint" },
+]
+lint = [
+    { name = "ruff" },
+    { name = "yamllint" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -332,10 +436,16 @@ requires-dist = [
     { name = "jinja2", marker = "extra == 'ci'" },
     { name = "kfp", specifier = ">=2.15.0" },
     { name = "kfp-components", extras = ["ci"], marker = "extra == 'dev'" },
+    { name = "kfp-components", extras = ["lint"], marker = "extra == 'dev'" },
+    { name = "kfp-components", extras = ["test"], marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'ci'" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
     { name = "pyyaml" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = "==0.8.4" },
+    { name = "yamllint", marker = "extra == 'lint'", specifier = "==1.35.1" },
 ]
-provides-extras = ["ci", "dev"]
+provides-extras = ["lint", "test", "ci", "dev"]
 
 [[package]]
 name = "kfp-pipeline-spec"
@@ -475,6 +585,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -554,6 +673,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]
@@ -676,6 +809,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/37/9c02181ef38d55b77d97c68b78e705fd14c0de0e5d085202bb2b52ce5be9/ruff-0.8.4.tar.gz", hash = "sha256:0d5f89f254836799af1615798caa5f80b7f935d7a670fad66c5007928e57ace8", size = 3402103, upload-time = "2024-12-19T13:36:26.286Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/67/f480bf2f2723b2e49af38ed2be75ccdb2798fca7d56279b585c8f553aaab/ruff-0.8.4-py3-none-linux_armv6l.whl", hash = "sha256:58072f0c06080276804c6a4e21a9045a706584a958e644353603d36ca1eb8a60", size = 10546415, upload-time = "2024-12-19T13:35:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/7a/5aba20312c73f1ce61814e520d1920edf68ca3b9c507bd84d8546a8ecaa8/ruff-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ffb60904651c00a1e0b8df594591770018a0f04587f7deeb3838344fe3adabac", size = 10346113, upload-time = "2024-12-19T13:35:29.922Z" },
+    { url = "https://files.pythonhosted.org/packages/76/f4/c41de22b3728486f0aa95383a44c42657b2db4062f3234ca36fc8cf52d8b/ruff-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ddf5d654ac0d44389f6bf05cee4caeefc3132a64b58ea46738111d687352296", size = 9943564, upload-time = "2024-12-19T13:35:33.455Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f0/afa0d2191af495ac82d4cbbfd7a94e3df6f62a04ca412033e073b871fc6d/ruff-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e248b1f0fa2749edd3350a2a342b67b43a2627434c059a063418e3d375cfe643", size = 10805522, upload-time = "2024-12-19T13:35:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/12/57/5d1e9a0fd0c228e663894e8e3a8e7063e5ee90f8e8e60cf2085f362bfa1a/ruff-0.8.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf197b98ed86e417412ee3b6c893f44c8864f816451441483253d5ff22c0e81e", size = 10306763, upload-time = "2024-12-19T13:35:39.257Z" },
+    { url = "https://files.pythonhosted.org/packages/04/df/f069fdb02e408be8aac6853583572a2873f87f866fe8515de65873caf6b8/ruff-0.8.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c41319b85faa3aadd4d30cb1cffdd9ac6b89704ff79f7664b853785b48eccdf3", size = 11359574, upload-time = "2024-12-19T13:35:44.519Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/04/37c27494cd02e4a8315680debfc6dfabcb97e597c07cce0044db1f9dfbe2/ruff-0.8.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:9f8402b7c4f96463f135e936d9ab77b65711fcd5d72e5d67597b543bbb43cf3f", size = 12094851, upload-time = "2024-12-19T13:35:48.975Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b1/c5d7fb68506cab9832d208d03ea4668da9a9887a4a392f4f328b1bf734ad/ruff-0.8.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4e56b3baa9c23d324ead112a4fdf20db9a3f8f29eeabff1355114dd96014604", size = 11655539, upload-time = "2024-12-19T13:35:52.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/38/8f8f2c8898dc8a7a49bc340cf6f00226917f0f5cb489e37075bcb2ce3671/ruff-0.8.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:736272574e97157f7edbbb43b1d046125fce9e7d8d583d5d65d0c9bf2c15addf", size = 12912805, upload-time = "2024-12-19T13:35:57.234Z" },
+    { url = "https://files.pythonhosted.org/packages/06/dd/fa6660c279f4eb320788876d0cff4ea18d9af7d9ed7216d7bd66877468d0/ruff-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fe710ab6061592521f902fca7ebcb9fabd27bc7c57c764298b1c1f15fff720", size = 11205976, upload-time = "2024-12-19T13:36:01.27Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d7/de94cc89833b5de455750686c17c9e10f4e1ab7ccdc5521b8fe911d1477e/ruff-0.8.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:13e9ec6d6b55f6da412d59953d65d66e760d583dd3c1c72bf1f26435b5bfdbae", size = 10792039, upload-time = "2024-12-19T13:36:04.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/15/3e4906559248bdbb74854af684314608297a05b996062c9d72e0ef7c7097/ruff-0.8.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:97d9aefef725348ad77d6db98b726cfdb075a40b936c7984088804dfd38268a7", size = 10400088, upload-time = "2024-12-19T13:36:08.362Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/21/9ed4c0e8133cb4a87a18d470f534ad1a8a66d7bec493bcb8bda2d1a5d5be/ruff-0.8.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ab78e33325a6f5374e04c2ab924a3367d69a0da36f8c9cb6b894a62017506111", size = 10900814, upload-time = "2024-12-19T13:36:12.877Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5d/122a65a18955bd9da2616b69bc839351f8baf23b2805b543aa2f0aed72b5/ruff-0.8.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8ef06f66f4a05c3ddbc9121a8b0cecccd92c5bf3dd43b5472ffe40b8ca10f0f8", size = 11268828, upload-time = "2024-12-19T13:36:15.718Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a9/1676ee9106995381e3d34bccac5bb28df70194167337ed4854c20f27c7ba/ruff-0.8.4-py3-none-win32.whl", hash = "sha256:552fb6d861320958ca5e15f28b20a3d071aa83b93caee33a87b471f99a6c0835", size = 8805621, upload-time = "2024-12-19T13:36:18.551Z" },
+    { url = "https://files.pythonhosted.org/packages/10/98/ed6b56a30ee76771c193ff7ceeaf1d2acc98d33a1a27b8479cbdb5c17a23/ruff-0.8.4-py3-none-win_amd64.whl", hash = "sha256:f21a1143776f8656d7f364bd264a9d60f01b7f52243fbe90e7670c0dfe0cf65d", size = 9660086, upload-time = "2024-12-19T13:36:21.323Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9f/026e18ca7d7766783d779dae5e9c656746c6ede36ef73c6d934aaf4a6dec/ruff-0.8.4-py3-none-win_arm64.whl", hash = "sha256:9183dd615d8df50defa8b1d9a074053891ba39025cf5ae88e8bcb52edcc4bf08", size = 9074500, upload-time = "2024-12-19T13:36:23.92Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -694,6 +852,55 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/ed/3f73f72945444548f33eba9a87fc7a6e969915e7b1acc8260b30e1f76a2f/tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549", size = 17392, upload-time = "2025-10-08T22:01:47.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/2e/299f62b401438d5fe1624119c723f5d877acc86a4c2492da405626665f12/tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45", size = 153236, upload-time = "2025-10-08T22:01:00.137Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7f/d8fffe6a7aefdb61bced88fcb5e280cfd71e08939da5894161bd71bea022/tomli-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:883b1c0d6398a6a9d29b508c331fa56adbcdff647f6ace4dfca0f50e90dfd0ba", size = 148084, upload-time = "2025-10-08T22:01:01.63Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/24935fb6a2ee63e86d80e4d3b58b222dafaf438c416752c8b58537c8b89a/tomli-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1381caf13ab9f300e30dd8feadb3de072aeb86f1d34a8569453ff32a7dea4bf", size = 234832, upload-time = "2025-10-08T22:01:02.543Z" },
+    { url = "https://files.pythonhosted.org/packages/89/da/75dfd804fc11e6612846758a23f13271b76d577e299592b4371a4ca4cd09/tomli-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0e285d2649b78c0d9027570d4da3425bdb49830a6156121360b3f8511ea3441", size = 242052, upload-time = "2025-10-08T22:01:03.836Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8c/f48ac899f7b3ca7eb13af73bacbc93aec37f9c954df3c08ad96991c8c373/tomli-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a154a9ae14bfcf5d8917a59b51ffd5a3ac1fd149b71b47a3a104ca4edcfa845", size = 239555, upload-time = "2025-10-08T22:01:04.834Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/28/72f8afd73f1d0e7829bfc093f4cb98ce0a40ffc0cc997009ee1ed94ba705/tomli-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:74bf8464ff93e413514fefd2be591c3b0b23231a77f901db1eb30d6f712fc42c", size = 245128, upload-time = "2025-10-08T22:01:05.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/eb/a7679c8ac85208706d27436e8d421dfa39d4c914dcf5fa8083a9305f58d9/tomli-2.3.0-cp311-cp311-win32.whl", hash = "sha256:00b5f5d95bbfc7d12f91ad8c593a1659b6387b43f054104cda404be6bda62456", size = 96445, upload-time = "2025-10-08T22:01:06.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/fe/3d3420c4cb1ad9cb462fb52967080575f15898da97e21cb6f1361d505383/tomli-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:4dc4ce8483a5d429ab602f111a93a6ab1ed425eae3122032db7e9acf449451be", size = 107165, upload-time = "2025-10-08T22:01:08.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b7/40f36368fcabc518bb11c8f06379a0fd631985046c038aca08c6d6a43c6e/tomli-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d7d86942e56ded512a594786a5ba0a5e521d02529b3826e7761a05138341a2ac", size = 154891, upload-time = "2025-10-08T22:01:09.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3f/d9dd692199e3b3aab2e4e4dd948abd0f790d9ded8cd10cbaae276a898434/tomli-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:73ee0b47d4dad1c5e996e3cd33b8a76a50167ae5f96a2607cbe8cc773506ab22", size = 148796, upload-time = "2025-10-08T22:01:10.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/83/59bff4996c2cf9f9387a0f5a3394629c7efa5ef16142076a23a90f1955fa/tomli-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:792262b94d5d0a466afb5bc63c7daa9d75520110971ee269152083270998316f", size = 242121, upload-time = "2025-10-08T22:01:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e5/7c5119ff39de8693d6baab6c0b6dcb556d192c165596e9fc231ea1052041/tomli-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f195fe57ecceac95a66a75ac24d9d5fbc98ef0962e09b2eddec5d39375aae52", size = 250070, upload-time = "2025-10-08T22:01:12.498Z" },
+    { url = "https://files.pythonhosted.org/packages/45/12/ad5126d3a278f27e6701abde51d342aa78d06e27ce2bb596a01f7709a5a2/tomli-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e31d432427dcbf4d86958c184b9bfd1e96b5b71f8eb17e6d02531f434fd335b8", size = 245859, upload-time = "2025-10-08T22:01:13.551Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a1/4d6865da6a71c603cfe6ad0e6556c73c76548557a8d658f9e3b142df245f/tomli-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b0882799624980785240ab732537fcfc372601015c00f7fc367c55308c186f6", size = 250296, upload-time = "2025-10-08T22:01:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/b7/a7a7042715d55c9ba6e8b196d65d2cb662578b4d8cd17d882d45322b0d78/tomli-2.3.0-cp312-cp312-win32.whl", hash = "sha256:ff72b71b5d10d22ecb084d345fc26f42b5143c5533db5e2eaba7d2d335358876", size = 97124, upload-time = "2025-10-08T22:01:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/f22f100db15a68b520664eb3328fb0ae4e90530887928558112c8d1f4515/tomli-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:1cb4ed918939151a03f33d4242ccd0aa5f11b3547d0cf30f7c74a408a5b99878", size = 107698, upload-time = "2025-10-08T22:01:16.51Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/06ee6eabe4fdd9ecd48bf488f4ac783844fd777f547b8d1b61c11939974e/tomli-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5192f562738228945d7b13d4930baffda67b69425a7f0da96d360b0a3888136b", size = 154819, upload-time = "2025-10-08T22:01:17.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/88793757d54d8937015c75dcdfb673c65471945f6be98e6a0410fba167ed/tomli-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be71c93a63d738597996be9528f4abe628d1adf5e6eb11607bc8fe1a510b5dae", size = 148766, upload-time = "2025-10-08T22:01:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/42/17/5e2c956f0144b812e7e107f94f1cc54af734eb17b5191c0bbfb72de5e93e/tomli-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4665508bcbac83a31ff8ab08f424b665200c0e1e645d2bd9ab3d3e557b6185b", size = 240771, upload-time = "2025-10-08T22:01:20.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f4/0fbd014909748706c01d16824eadb0307115f9562a15cbb012cd9b3512c5/tomli-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4021923f97266babc6ccab9f5068642a0095faa0a51a246a6a02fccbb3514eaf", size = 248586, upload-time = "2025-10-08T22:01:21.164Z" },
+    { url = "https://files.pythonhosted.org/packages/30/77/fed85e114bde5e81ecf9bc5da0cc69f2914b38f4708c80ae67d0c10180c5/tomli-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4ea38c40145a357d513bffad0ed869f13c1773716cf71ccaa83b0fa0cc4e42f", size = 244792, upload-time = "2025-10-08T22:01:22.417Z" },
+    { url = "https://files.pythonhosted.org/packages/55/92/afed3d497f7c186dc71e6ee6d4fcb0acfa5f7d0a1a2878f8beae379ae0cc/tomli-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad805ea85eda330dbad64c7ea7a4556259665bdf9d2672f5dccc740eb9d3ca05", size = 248909, upload-time = "2025-10-08T22:01:23.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/ef50c51b5a9472e7265ce1ffc7f24cd4023d289e109f669bdb1553f6a7c2/tomli-2.3.0-cp313-cp313-win32.whl", hash = "sha256:97d5eec30149fd3294270e889b4234023f2c69747e555a27bd708828353ab606", size = 96946, upload-time = "2025-10-08T22:01:24.893Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b7/718cd1da0884f281f95ccfa3a6cc572d30053cba64603f79d431d3c9b61b/tomli-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c95ca56fbe89e065c6ead5b593ee64b84a26fca063b5d71a1122bf26e533999", size = 107705, upload-time = "2025-10-08T22:01:26.153Z" },
+    { url = "https://files.pythonhosted.org/packages/19/94/aeafa14a52e16163008060506fcb6aa1949d13548d13752171a755c65611/tomli-2.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:cebc6fe843e0733ee827a282aca4999b596241195f43b4cc371d64fc6639da9e", size = 154244, upload-time = "2025-10-08T22:01:27.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e4/1e58409aa78eefa47ccd19779fc6f36787edbe7d4cd330eeeedb33a4515b/tomli-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c2ef0244c75aba9355561272009d934953817c49f47d768070c3c94355c2aa3", size = 148637, upload-time = "2025-10-08T22:01:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b6/d1eccb62f665e44359226811064596dd6a366ea1f985839c566cd61525ae/tomli-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c22a8bf253bacc0cf11f35ad9808b6cb75ada2631c2d97c971122583b129afbc", size = 241925, upload-time = "2025-10-08T22:01:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/70/91/7cdab9a03e6d3d2bb11beae108da5bdc1c34bdeb06e21163482544ddcc90/tomli-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0eea8cc5c5e9f89c9b90c4896a8deefc74f518db5927d0e0e8d4a80953d774d0", size = 249045, upload-time = "2025-10-08T22:01:31.98Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/8c26874ed1f6e4f1fcfeb868db8a794cbe9f227299402db58cfcc858766c/tomli-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b74a0e59ec5d15127acdabd75ea17726ac4c5178ae51b85bfe39c4f8a278e879", size = 245835, upload-time = "2025-10-08T22:01:32.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/42/8e3c6a9a4b1a1360c1a2a39f0b972cef2cc9ebd56025168c4137192a9321/tomli-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b5870b50c9db823c595983571d1296a6ff3e1b88f734a4c8f6fc6188397de005", size = 253109, upload-time = "2025-10-08T22:01:34.052Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0c/b4da635000a71b5f80130937eeac12e686eefb376b8dee113b4a582bba42/tomli-2.3.0-cp314-cp314-win32.whl", hash = "sha256:feb0dacc61170ed7ab602d3d972a58f14ee3ee60494292d384649a3dc38ef463", size = 97930, upload-time = "2025-10-08T22:01:35.082Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/74/cb1abc870a418ae99cd5c9547d6bce30701a954e0e721821df483ef7223c/tomli-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:b273fcbd7fc64dc3600c098e39136522650c49bca95df2d11cf3b626422392c8", size = 107964, upload-time = "2025-10-08T22:01:36.057Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/5c46fff6432a712af9f792944f4fcd7067d8823157949f4e40c56b8b3c83/tomli-2.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:940d56ee0410fa17ee1f12b817b37a4d4e4dc4d27340863cc67236c74f582e77", size = 163065, upload-time = "2025-10-08T22:01:37.27Z" },
+    { url = "https://files.pythonhosted.org/packages/39/67/f85d9bd23182f45eca8939cd2bc7050e1f90c41f4a2ecbbd5963a1d1c486/tomli-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f85209946d1fe94416debbb88d00eb92ce9cd5266775424ff81bc959e001acaf", size = 159088, upload-time = "2025-10-08T22:01:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5a/4b546a0405b9cc0659b399f12b6adb750757baf04250b148d3c5059fc4eb/tomli-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a56212bdcce682e56b0aaf79e869ba5d15a6163f88d5451cbde388d48b13f530", size = 268193, upload-time = "2025-10-08T22:01:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4f/2c12a72ae22cf7b59a7fe75b3465b7aba40ea9145d026ba41cb382075b0e/tomli-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5f3ffd1e098dfc032d4d3af5c0ac64f6d286d98bc148698356847b80fa4de1b", size = 275488, upload-time = "2025-10-08T22:01:40.773Z" },
+    { url = "https://files.pythonhosted.org/packages/92/04/a038d65dbe160c3aa5a624e93ad98111090f6804027d474ba9c37c8ae186/tomli-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e01decd096b1530d97d5d85cb4dff4af2d8347bd35686654a004f8dea20fc67", size = 272669, upload-time = "2025-10-08T22:01:41.824Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2f/8b7c60a9d1612a7cbc39ffcca4f21a73bf368a80fc25bccf8253e2563267/tomli-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8a35dd0e643bb2610f156cca8db95d213a90015c11fee76c946aa62b7ae7e02f", size = 279709, upload-time = "2025-10-08T22:01:43.177Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -709,4 +916,17 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "yamllint"
+version = "1.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathspec" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/06/d8cee5c3dfd550cc0a466ead8b321138198485d1034130ac1393cc49d63e/yamllint-1.35.1.tar.gz", hash = "sha256:7a003809f88324fd2c877734f2d575ee7881dd9043360657cc8049c809eba6cd", size = 134583, upload-time = "2024-02-16T10:50:18.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/28/2abf1ec14df2d584b9e7ce3b0be458838741e6aaff7a540374ba9af83916/yamllint-1.35.1-py3-none-any.whl", hash = "sha256:2e16e504bb129ff515b37823b472750b36b6de07963bd74b307341ef5ad8bdc3", size = 66738, upload-time = "2024-02-16T10:50:16.06Z" },
 ]


### PR DESCRIPTION
This PR adds the linting framework and import guard for Kubeflow Pipelines Components as specified in KEP-913.
Description:

- Configured Black formatter and pydocstyle (Google-style docstrings) via pyproject.toml
- Added markdownlint and yamllint for docs and YAML files
- Implemented custom import guard to enforce stdlib-only top-level imports with exceptions via scripts/import_exceptions.json
- Added Makefile targets for make lint and make format
- Created GitHub Actions workflow to run all linters on PRs, scoped to changed files
- Ensures dev/test dependencies are declared in dev-requirements.txt or test-requirements.txt
- Workflow fails PR if any lint violations are detected