### PR TITLE
Add Pytest & Example Pipeline Validation with CI Workflow

### DIFF
--- a/.github/workflows/component-pipeline-tests.yml
+++ b/.github/workflows/component-pipeline-tests.yml
@@ -1,0 +1,60 @@
+---
+name: Run Tests and Validate Example Pipelines for Updated Components
+
+on:
+  pull_request:
+    paths:
+      - "components/**"
+      - "pipelines/**"
+      - "scripts/tests/**"
+      - "scripts/validate_examples/**"
+      - ".github/workflows/component-pipeline-tests.yml"
+  push:
+    branches:
+      - main
+      - release-*
+    paths:
+      - "components/**"
+      - "pipelines/**"
+      - "scripts/tests/**"
+      - "scripts/validate_examples/**"
+      - ".github/workflows/component-pipeline-tests.yml"
+
+jobs:
+  targeted-tests:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python CI
+        uses: ./.github/actions/setup-python-ci
+        with:
+          python-version: "3.11"
+
+      - name: Detect changed files
+        id: changes
+        uses: ./.github/actions/detect-changed-assets
+
+      - name: Run targeted pytest suites
+        if: ${{ steps.changes.outputs.has-changes == 'true' }}
+        run: |
+          echo "Running pytest for the following paths:"
+          PATHS="${{ steps.changes.outputs.changed-components }} ${{ steps.changes.outputs.changed-pipelines }}"
+          echo "$PATHS"
+          uv run python -m scripts.tests.run_component_tests $PATHS
+
+      - name: Validate example pipelines
+        if: ${{ steps.changes.outputs.has-changes == 'true' }}
+        run: |
+          echo "Validating example pipelines for:"
+          PATHS="${{ steps.changes.outputs.changed-components }} ${{ steps.changes.outputs.changed-pipelines }}"
+          echo "$PATHS"
+          uv run python -m scripts.validate_examples $PATHS
+
+      - name: No component changes detected
+        if: ${{ steps.changes.outputs.has-changes != 'true' }}
+        run: echo "No components or pipelines changed. Skipping targeted tests."

--- a/docs/BESTPRACTICES.md
+++ b/docs/BESTPRACTICES.md
@@ -1,11 +1,36 @@
 # Component Development Best Practices
 
-*This guide is under development. Please check back soon for comprehensive best practices for developing Kubeflow
-Pipelines components.*
+The sections below capture the minimum expectations for component and pipeline
+authors. Additional guidance will be added over time as the repository matures.
 
-## Coming Soon
+## Writing Component/Pipeline Smoke Tests
 
-This document will cover:
+- Keep test dependencies limited to `pytest` and the Python standard library.
+- Place tests in a `tests/` folder that sits next to the component or pipeline
+  (for example `components/training/my_component/tests/`).
+- Aim for fast smoke coverage (import checks, signature validation, lightweight
+  golden tests) that finishes well under the two-minute timeout enforced by
+  CI.
+- Run `python scripts/tests/run_component_tests.py <path-to-component>` locally
+  to execute only the suites you are touching. The helper automatically enforces
+  the `pytest-timeout` guardrail used in CI.
+
+## Validating Example Pipelines
+
+- Keep example pipelines in an `example_pipelines.py` module beside the asset.
+  Every pipeline exported from the module must be decorated with
+  `@dsl.pipeline`.
+- The CI workflow imports each module by running
+  `python -m scripts.validate_examples <paths>` for
+  every changed component or pipeline and compiles the matching sample pipelines
+  using `kfp.compiler`. Run the same command locally (with or without explicit
+  paths) before submitting a PR to catch syntax or dependency regressions early.
+- Keep the examples dependency-light; they should compile without extra
+  installations beyond the repo's base tooling (`kfp`, `pytest`, stdlib).
+
+## Additional Topics (Coming Soon)
+
+Future revisions of this guide will capture:
 
 - Component design patterns
 - Performance optimization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ test = [
 ]
 ci = [
     "pytest",
+    "pytest-timeout",
     "docstring-parser",
     "jinja2",
     "semver",

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for components and pipelines."""

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Pytest discovery and execution utilities for component and pipeline tests."""

--- a/scripts/tests/run_component_tests.py
+++ b/scripts/tests/run_component_tests.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Pytest discovery helper for Kubeflow components and pipelines.
+
+This script discovers `tests/` directories under the provided component or
+pipeline paths and runs pytest with a two-minute timeout per test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import warnings
+from pathlib import Path
+from typing import List, Sequence
+
+import pytest
+
+from ..utils import get_repo_root, normalize_targets
+
+REPO_ROOT = get_repo_root()
+TIMEOUT_SECONDS = 120
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Discover tests/ directories for the specified components or pipelines "
+            "and execute pytest with a two-minute timeout per test."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        metavar="PATH",
+        nargs="*",
+        help=(
+            "Component or pipeline directories (or files within them) to test. "
+            "If omitted, all components and pipelines are scanned."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=TIMEOUT_SECONDS,
+        help="Per-test timeout in seconds (default: 120).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Pass the -vv flag to pytest for more detailed output.",
+    )
+    return parser.parse_args()
+
+
+def discover_test_dirs(targets: Sequence[Path]) -> List[Path]:
+    """Discover tests/ directories under the given targets.
+
+    Args:
+        targets: Sequence of component or pipeline paths to search.
+
+    Returns:
+        List of discovered tests/ directory paths.
+    """
+    discovered: List[Path] = []
+
+    for target in targets:
+        search_root = target if target.is_dir() else target.parent
+        if not search_root.exists():
+            continue
+
+        direct = search_root / "tests"
+        if direct.is_dir() and _is_member_of_pipeline_or_component(direct):
+            if direct not in discovered:
+                discovered.append(direct)
+
+    return discovered
+
+
+def _is_member_of_pipeline_or_component(candidate: Path) -> bool:
+    """Check if a path is within components/ or pipelines/ directory.
+
+    Args:
+        candidate: Path to check.
+
+    Returns:
+        True if the path is within components/ or pipelines/, False otherwise.
+    """
+    try:
+        relative = candidate.relative_to(REPO_ROOT)
+    except ValueError:
+        warnings.warn(
+            f"Unable to determine relative path for {candidate} " f"relative to repo root {REPO_ROOT}. Skipping.",
+        )
+        return False
+
+    return relative.parts and relative.parts[0] in {"components", "pipelines"}
+
+
+def build_pytest_args(
+    test_dirs: Sequence[Path],
+    timeout_seconds: int,
+    verbose: bool,
+) -> List[str]:
+    """Build pytest command-line arguments.
+
+    Args:
+        test_dirs: Directories containing tests to run.
+        timeout_seconds: Per-test timeout in seconds.
+        verbose: Whether to enable verbose pytest output.
+
+    Returns:
+        List of pytest command-line arguments.
+    """
+    args: List[str] = [
+        f"--timeout={timeout_seconds}",
+        "--timeout-method=signal",
+    ]
+    if verbose:
+        args.append("-vv")
+
+    args.extend(str(directory) for directory in test_dirs)
+    return args
+
+
+def main() -> int:
+    """Main entry point for running component/pipeline tests.
+
+    Returns:
+        Exit code (0 for success, non-zero for failure).
+    """
+    args = parse_args()
+    targets = normalize_targets(args.paths)
+    test_dirs = discover_test_dirs(targets)
+
+    if not test_dirs:
+        print("No tests/ directories found under the supplied paths. Nothing to do.")
+        return 0
+
+    relative_dirs = ", ".join(str(directory.relative_to(REPO_ROOT)) for directory in test_dirs)
+    print(f"Running pytest for: {relative_dirs}")
+
+    pytest_args = build_pytest_args(
+        test_dirs=test_dirs,
+        timeout_seconds=args.timeout,
+        verbose=args.verbose,
+    )
+
+    exit_code = pytest.main(pytest_args)
+    if exit_code == 0:
+        print("✅ Pytest completed successfully.")
+    else:
+        print("❌ Pytest reported failures. See log above for details.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -1,0 +1,19 @@
+"""Shared utilities for scripts."""
+
+from .parsing import (
+    find_functions_with_decorator,
+    find_pipeline_functions,
+)
+from .paths import (
+    get_default_targets,
+    get_repo_root,
+    normalize_targets,
+)
+
+__all__ = [
+    "find_functions_with_decorator",
+    "find_pipeline_functions",
+    "get_default_targets",
+    "get_repo_root",
+    "normalize_targets",
+]

--- a/scripts/utils/parsing.py
+++ b/scripts/utils/parsing.py
@@ -1,0 +1,97 @@
+"""Parsing-related utility functions."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List
+
+
+def get_ast_tree(file_path: Path) -> ast.AST:
+    """Get the parsed AST tree for a Python file.
+
+    Args:
+        file_path: Path to the Python file to parse.
+
+    Returns:
+        The parsed AST tree.
+    """
+    with open(file_path, "r", encoding="utf-8") as f:
+        source = f.read()
+    return ast.parse(source)
+
+
+def is_target_decorator(decorator: ast.AST, decorator_type: str) -> bool:
+    """Check if a decorator is a KFP component or pipeline decorator.
+
+    Supports the following decorator formats (using component as an example):
+    - @component (direct import: from kfp.dsl import component)
+    - @dsl.component (from kfp import dsl)
+    - @kfp.dsl.component (import kfp)
+    - All of the above with parentheses: @component(), @dsl.component(), etc.
+
+    Args:
+        decorator: AST node representing the decorator.
+        decorator_type: Type of decorator to find ('component' or 'pipeline').
+
+    Returns:
+        True if the decorator is the given decoration_type, False otherwise.
+    """
+    if isinstance(decorator, ast.Attribute):
+        # Handle attribute-based decorators
+        if decorator.attr == decorator_type:
+            # Check for @dsl.<function_type>
+            if isinstance(decorator.value, ast.Name) and decorator.value.id == "dsl":
+                return True
+            # Check for @kfp.dsl.<function_type>
+            if (
+                isinstance(decorator.value, ast.Attribute)
+                and decorator.value.attr == "dsl"
+                and isinstance(decorator.value.value, ast.Name)
+                and decorator.value.value.id == "kfp"
+            ):
+                return True
+        return False
+    elif isinstance(decorator, ast.Call):
+        # Handle decorators with arguments (e.g., @<function_type>(), @dsl.<function_type>())
+        return is_target_decorator(decorator.func, decorator_type)
+    elif isinstance(decorator, ast.Name):
+        # Handle @<function_type> (if imported directly)
+        return decorator.id == decorator_type
+    return False
+
+
+def find_pipeline_functions(file_path: Path) -> List[str]:
+    """Find all function names decorated with @dsl.pipeline.
+
+    Args:
+        file_path: Path to the Python file to parse.
+
+    Returns:
+        List of function names that are decorated with @dsl.pipeline.
+    """
+    return find_functions_with_decorator(file_path, "pipeline")
+
+
+def find_functions_with_decorator(file_path: Path, decorator_type: str) -> List[str]:
+    """Find all function names decorated with a specific KFP decorator
+
+    Args:
+        file_path: Path to the Python file to parse.
+        decorator_type: Type of decorator to find ('component' or 'pipeline').
+
+    Returns:
+        List of function names that are decorated with the specified decorator.
+    """
+    tree = get_ast_tree(file_path)
+
+    functions: List[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in node.decorator_list:
+                if is_target_decorator(decorator, decorator_type):
+                    functions.append(node.name)
+                    break  # Found the decorator, no need to check other decorators
+
+    return functions

--- a/scripts/utils/paths.py
+++ b/scripts/utils/paths.py
@@ -1,0 +1,48 @@
+"""Path-related utility functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).resolve().parents[2]
+
+
+def get_default_targets() -> tuple[Path, Path]:
+    """Get the default component and pipeline target directories."""
+    repo_root = get_repo_root()
+    return (repo_root / "components", repo_root / "pipelines")
+
+
+def normalize_targets(raw_paths: Sequence[str]) -> List[Path]:
+    """Normalize target paths to absolute Path objects.
+
+    Args:
+        raw_paths: Sequence of path strings (can be relative or absolute).
+
+    Returns:
+        List of normalized absolute Path objects.
+
+    Raises:
+        FileNotFoundError: If any specified path does not exist.
+    """
+    repo_root = get_repo_root()
+    default_targets = get_default_targets()
+
+    if not raw_paths:
+        return [target for target in default_targets if target.exists()]
+
+    normalized: List[Path] = []
+    for raw in raw_paths:
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            candidate = (repo_root / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+        if not candidate.exists():
+            raise FileNotFoundError(f"Specified path does not exist: {raw}")
+        normalized.append(candidate)
+    return normalized

--- a/scripts/validate_examples/__init__.py
+++ b/scripts/validate_examples/__init__.py
@@ -1,0 +1,6 @@
+"""Validate example pipeline modules by compiling exported pipelines.
+
+This package provides utilities to discover and validate example_pipelines.py
+modules for components and pipelines, ensuring all exported @dsl.pipeline
+functions compile successfully.
+"""

--- a/scripts/validate_examples/__main__.py
+++ b/scripts/validate_examples/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for running validate_examples as a module."""
+
+import sys
+
+from .validate_examples import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_examples/validate_examples.py
+++ b/scripts/validate_examples/validate_examples.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Validate example_pipelines modules by compiling every exported pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import tempfile
+import traceback
+import warnings
+from pathlib import Path
+from types import ModuleType
+from typing import List, Sequence, Tuple
+
+from kfp import compiler
+
+from ..utils import find_pipeline_functions, get_repo_root, normalize_targets
+
+REPO_ROOT = get_repo_root()
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Import example_pipelines.py modules for the specified components or pipelines "
+            "and compile every @dsl.pipeline function they export."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        metavar="PATH",
+        nargs="*",
+        help=(
+            "Component or pipeline directories (or files within them). "
+            "If omitted, every example_pipelines.py file is validated."
+        ),
+    )
+    return parser.parse_args()
+
+
+def discover_example_files(targets: Sequence[Path]) -> List[Path]:
+    """Discover example_pipelines.py files under the given targets.
+
+    Args:
+        targets: Sequence of component or pipeline paths to search.
+
+    Returns:
+        List of discovered example_pipelines.py file paths.
+    """
+    discovered: List[Path] = []
+
+    for target in targets:
+        search_root = target if target.is_dir() else target.parent
+
+        for candidate in search_root.rglob("example_pipelines.py"):
+            if candidate in discovered or not candidate.is_file():
+                continue
+            try:
+                relative = candidate.relative_to(REPO_ROOT)
+            except ValueError:
+                warnings.warn(
+                    f"Unable to determine relative path for {candidate} "
+                    f"relative to repo root {REPO_ROOT}. Skipping.",
+                )
+                continue
+            if relative.parts and relative.parts[0] in {"components", "pipelines"}:
+                discovered.append(candidate)
+
+    return discovered
+
+
+def load_module_from_path(module_path: Path) -> ModuleType:
+    """Load a Python module from a file path.
+
+    Args:
+        module_path: Path to the Python file to load.
+
+    Returns:
+        The loaded module object.
+
+    Raises:
+        ImportError: If the module cannot be loaded.
+    """
+    relative = module_path.relative_to(REPO_ROOT)
+    sanitized = "_".join(relative.with_suffix("").parts)
+    module_name = f"example_pipelines__{sanitized}"
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def collect_pipeline_functions(module_path: Path, module: ModuleType) -> List[Tuple[str, object]]:
+    """Collect pipeline functions from a module.
+
+    Args:
+        module_path: Path to the Python file.
+        module: The loaded module.
+
+    Returns:
+        List of (function_name, callable) tuples for pipeline functions.
+    """
+    pipeline_names = find_pipeline_functions(module_path)
+
+    pipelines: List[Tuple[str, object]] = []
+    for name in pipeline_names:
+        if hasattr(module, name):
+            callable_obj = getattr(module, name)
+            if callable(callable_obj):
+                pipelines.append((name, callable_obj))
+
+    return pipelines
+
+
+def compile_pipeline(pipeline_callable: object, output_stub: str) -> None:
+    """Compile a pipeline function to a JSON package.
+
+    Args:
+        pipeline_callable: The pipeline function to compile.
+        output_stub: Base name for the output file (without extension).
+
+    Raises:
+        Exception: If compilation fails.
+    """
+    compiler_instance = compiler.Compiler()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        package_path = Path(temp_dir) / f"{output_stub}.json"
+        compiler_instance.compile(
+            pipeline_func=pipeline_callable,
+            package_path=str(package_path),
+        )
+
+
+def main() -> int:
+    """Main entry point for validating example pipelines.
+
+    Returns:
+        Exit code (0 for success, non-zero for failure).
+    """
+    args = parse_args()
+    targets = normalize_targets(args.paths)
+    example_files = discover_example_files(targets)
+
+    if not example_files:
+        print("No example_pipelines.py modules found. Nothing to validate.")
+        return 0
+
+    failures: List[str] = []
+    compiled: List[str] = []
+
+    for module_path in example_files:
+        module = load_module_from_path(module_path)
+        pipelines = collect_pipeline_functions(module_path, module)
+        if not pipelines:
+            print(f"⚠️  {module_path.relative_to(REPO_ROOT)} exports no @dsl.pipeline functions.")
+            continue
+
+        for pipeline_name, pipeline_callable in pipelines:
+            stub_name = f"{module_path.stem}__{pipeline_name}"
+            try:
+                compile_pipeline(pipeline_callable, stub_name)
+                compiled.append(f"{module_path.relative_to(REPO_ROOT)}::{pipeline_name}")
+            except Exception:
+                tb = traceback.format_exc()
+                failure_message = f"{module_path.relative_to(REPO_ROOT)}::{pipeline_name} failed to compile:\n{tb}"
+                failures.append(failure_message)
+
+    for entry in compiled:
+        print(f"✅ Compiled {entry}")
+
+    if failures:
+        print("❌ Example pipeline compilation failures detected:")
+        for failure in failures:
+            print(failure)
+        return 1
+
+    print("All discovered example pipelines compiled successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -428,6 +428,7 @@ ci = [
     { name = "docstring-parser" },
     { name = "jinja2" },
     { name = "pytest" },
+    { name = "pytest-timeout" },
     { name = "semver" },
 ]
 dev = [
@@ -436,6 +437,7 @@ dev = [
     { name = "jinja2" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "semver" },
     { name = "yamllint" },
@@ -462,6 +464,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'ci'" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
+    { name = "pytest-timeout", marker = "extra == 'ci'" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'lint'", specifier = "==0.8.4" },
     { name = "semver", marker = "extra == 'ci'" },
@@ -709,6 +712,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces CI automation to discover component/pipeline tests, enforce pytest runs with per-test timeouts, and compile all example_pipelines.py samples. 
The GitHub Actions workflow detects which components/pipelines changed in a PR, and runs both helper scripts only for those paths.

**Key additions:**

- `scripts/run_tests.py` – Discovers tests/ folders, normalizes paths, and runs pytest with the pytest-timeout guardrail.
- `scripts/validate_examples.py `– Imports every matching example_pipelines.py, finds @dsl.pipeline callables, and compiles them with kfp.compiler.
- `.github/workflows/test.yml `– Targeted CI workflow to test and validate only the changed assets.