### PR TITLE
chore: reduce root owners to minimal approvers while repo is prepared

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,15 +5,5 @@
 # Approvers are responsible for approving code changes
 # These are the KFP maintainers who have write access
 approvers:
-  - chensun
-  - droctothorpe
   - HumairAK
-  - james-jwu
   - mprahl
-  - zazulam
-
-# Reviewers are responsible for reviewing code changes
-# These include both maintainers and additional reviewers
-reviewers:
-  - chensun
-  - HumairAK

--- a/components/deployment/component_valid/OWNERS
+++ b/components/deployment/component_valid/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- sample-approver

--- a/components/deployment/component_valid/metadata.yaml
+++ b/components/deployment/component_valid/metadata.yaml
@@ -1,0 +1,22 @@
+name: invalid-dependency-semantic-versioning
+tier: third_party
+stability: stable
+dependencies:
+  kubeflow:
+    - name: Pipelines
+      version: '>=2.5.0'
+    - name: Trainer
+      version: '>=2.0.0'
+  external_services:
+    - name: Argo Workflows
+      version: "3.6.0"
+tags:
+  - training
+  - evaluation
+lastVerified: 2025-03-15T00:00:00Z
+ci:
+  skip_dependency_probe: false
+links:
+  documentation: https://kubeflow.org/components/happy-path-component
+  issue_tracker: https://github.com/kubeflow/kfp-components/issues
+  whatever: foo


### PR DESCRIPTION
Let's keep the reviewer/approver burden minimal while this repo is being prepared so as not to spam everyone. If any of the approvers here want to be directly involved with the construction and project maintenance of this repo, please reach out to myself & @mprahl, thank you. 