### PR TITLE
ci: Added path filters for config and dependency files

### DIFF
--- a/.github/workflows/base-image-check.yml
+++ b/.github/workflows/base-image-check.yml
@@ -1,3 +1,4 @@
+---
 name: Base Image Validation
 
 on:
@@ -15,6 +16,9 @@ on:
       - 'scripts/validate_base_images/**'
       - '.github/scripts/utils/**'
       - '.github/workflows/base-image-check.yml'
+      - '.github/actions/setup-python-ci/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 # Cancel in-progress runs when a new commit is pushed to the same PR
 concurrency:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,7 +2,11 @@
 name: Markdown Lint
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.markdownlint.json'
+      - '.github/workflows/markdown-lint.yml'
   push:
     branches:
       - main

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -2,7 +2,14 @@
 name: Python Lint
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/python-lint.yml'
+      - '.github/actions/setup-python-ci/**'
+      - '.github/scripts/check_imports/**'
   push:
     branches:
       - main

--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -8,7 +8,10 @@ on:
       - 'pipelines/**'
       - 'scripts/generate_readme/**'
       - '.github/workflows/readme-check.yml'
+      - '.github/actions/setup-python-ci/**'
       - '.github/scripts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   check-readme-sync:
@@ -45,11 +48,8 @@ jobs:
           echo "${{ steps.changed-files.outputs.all_changed_files }}"
 
           # Extract unique component/pipeline directories from changed files
-          targets=$(
-            ./.github/scripts/utils/find-changed-components-and-pipelines.sh \
-              ${{ steps.changed-files.outputs.all_changed_files }}
-          )
-
+          targets=$(./.github/scripts/utils/find-changed-components-and-pipelines.sh \
+            ${{ steps.changed-files.outputs.all_changed_files }})
           echo "targets=$targets" >> $GITHUB_OUTPUT
           echo "Targets to check: $targets"
 

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -1,3 +1,4 @@
+---
 name: Scripts Unit Tests
 
 on:
@@ -15,6 +16,7 @@ on:
       - '.github/workflows/scripts-tests.yml'
       - '.github/actions/setup-python-ci/**'
       - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   test-scripts:

--- a/.github/workflows/validate-metadata-schema.yml
+++ b/.github/workflows/validate-metadata-schema.yml
@@ -9,6 +9,10 @@ on:
       - 'components/**'
       - 'pipelines/**'
       - 'scripts/**'
+      - '.github/workflows/validate-metadata-schema.yml'
+      - '.github/actions/setup-python-ci/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   validate-metadata-schema:

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -2,7 +2,15 @@
 name: YAML Lint
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '.yamllint.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/yaml-lint.yml'
+      - '.github/actions/setup-python-ci/**'
   push:
     branches:
       - main


### PR DESCRIPTION
**Description of your changes:**

Add path filters to workflows to run when relevant files change:

- Add `uv.lock` to all workflows using uv
- Add config files: `pyproject.toml`, `.yamllint.yml`, `.markdownlint.json`
- Add `.github/actions/setup-python-ci/**` to workflows using this action
- Add workflow self-references and related script paths

This ensures CI runs when configurations or dependencies change while reducing unnecessary workflow runs.

**Checklist:**
### Pre-Submission Checklist
- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

### Additional Checklist Items for New or Updated Components/Pipelines:
- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files) are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
