### PR TITLE
fix(CI): Add missing CI dependencies and pin them

### DIFF
--- a/.github/actions/setup-python-ci/action.yml
+++ b/.github/actions/setup-python-ci/action.yml
@@ -7,9 +7,9 @@ inputs:
     description: 'Python version to use'
     required: true
   extra:
-    description: 'uv extra group to install (defaults to ci)'
+    description: 'uv extra group to install (defaults to test)'
     required: false
-    default: ci
+    default: test
 
 runs:
   using: 'composite'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,20 +24,17 @@ lint = [
     "yamllint==1.35.1",
 ]
 test = [
-    "pytest",
-    "pytest-cov",
-    "docker",
+    # Pinned for reproducible test/CI runs
+    "docker==7.1.0",
+    "pytest==9.0.2",
+    "pytest-cov==7.0.0",
+    "pytest-timeout==2.4.0",
+    "docstring-parser==0.17.0",
+    "jinja2==3.1.6",
+    "semver==3.0.4",
 ]
-ci = [
-    "pytest",
-    "pytest-timeout",
-    "docstring-parser",
-    "jinja2",
-    "semver",
-]
-# Local development (extends ci with additional tools)
+# Local development (extends test with additional tools)
 dev = [
-    "kfp-components[ci]",
     "kfp-components[lint]",
     "kfp-components[test]",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -424,13 +424,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-ci = [
-    { name = "docstring-parser" },
-    { name = "jinja2" },
-    { name = "pytest" },
-    { name = "pytest-timeout" },
-    { name = "semver" },
-]
 dev = [
     { name = "docker" },
     { name = "docstring-parser" },
@@ -448,29 +441,31 @@ lint = [
 ]
 test = [
     { name = "docker" },
+    { name = "docstring-parser" },
+    { name = "jinja2" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
+    { name = "semver" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "docker", marker = "extra == 'test'" },
-    { name = "docstring-parser", marker = "extra == 'ci'" },
-    { name = "jinja2", marker = "extra == 'ci'" },
+    { name = "docker", marker = "extra == 'test'", specifier = "==7.1.0" },
+    { name = "docstring-parser", marker = "extra == 'test'", specifier = "==0.17.0" },
+    { name = "jinja2", marker = "extra == 'test'", specifier = "==3.1.6" },
     { name = "kfp", specifier = ">=2.15.2" },
-    { name = "kfp-components", extras = ["ci"], marker = "extra == 'dev'" },
     { name = "kfp-components", extras = ["lint"], marker = "extra == 'dev'" },
     { name = "kfp-components", extras = ["test"], marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'ci'" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytest-cov", marker = "extra == 'test'" },
-    { name = "pytest-timeout", marker = "extra == 'ci'" },
+    { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.2" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = "==7.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'test'", specifier = "==2.4.0" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'lint'", specifier = "==0.8.4" },
-    { name = "semver", marker = "extra == 'ci'" },
+    { name = "semver", marker = "extra == 'test'", specifier = "==3.0.4" },
     { name = "yamllint", marker = "extra == 'lint'", specifier = "==1.35.1" },
 ]
-provides-extras = ["lint", "test", "ci", "dev"]
+provides-extras = ["lint", "test", "dev"]
 
 [[package]]
 name = "kfp-pipeline-spec"


### PR DESCRIPTION
**Description of your changes:**

This consolidates the `ci` and `test` dependency groups for simplicity. The `ci` one was missing `docker`, so component tests failed when local runner was missing.

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

