### PR TITLE
chore: Unpinned test dependencies, add uv.lock sync check in pre-commit and CI

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -35,6 +35,9 @@ jobs:
           python-version: "3.11"
           extra: lint
 
+      - name: Check uv.lock is in sync
+        run: uv lock --check
+
       - name: Determine changed Python files
         id: changed-python
         uses: ./.github/actions/detect-changed-assets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@
 repos:
   - repo: local
     hooks:
+      - id: uv-lock-check
+        name: uv lock check
+        entry: uv lock --check
+        language: system
+        files: (^pyproject\.toml$|^uv\.lock$)
+        pass_filenames: false
       - id: ruff-format
         name: ruff format
         entry: uv run ruff format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,13 @@ lint = [
     "yamllint==1.35.1",
 ]
 test = [
-    # Pinned for reproducible test/CI runs
-    "docker==7.1.0",
-    "pytest==9.0.2",
-    "pytest-cov==7.0.0",
-    "pytest-timeout==2.4.0",
-    "docstring-parser==0.17.0",
-    "jinja2==3.1.6",
-    "semver==3.0.4",
+    "docker",
+    "pytest",
+    "pytest-cov",
+    "pytest-timeout",
+    "docstring-parser",
+    "jinja2",
+    "semver",
 ]
 # Local development (extends test with additional tools)
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -451,18 +451,18 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "docker", marker = "extra == 'test'", specifier = "==7.1.0" },
-    { name = "docstring-parser", marker = "extra == 'test'", specifier = "==0.17.0" },
-    { name = "jinja2", marker = "extra == 'test'", specifier = "==3.1.6" },
+    { name = "docker", marker = "extra == 'test'" },
+    { name = "docstring-parser", marker = "extra == 'test'" },
+    { name = "jinja2", marker = "extra == 'test'" },
     { name = "kfp", specifier = ">=2.15.2" },
     { name = "kfp-components", extras = ["lint"], marker = "extra == 'dev'" },
     { name = "kfp-components", extras = ["test"], marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.2" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = "==7.0.0" },
-    { name = "pytest-timeout", marker = "extra == 'test'", specifier = "==2.4.0" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-cov", marker = "extra == 'test'" },
+    { name = "pytest-timeout", marker = "extra == 'test'" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'lint'", specifier = "==0.8.4" },
-    { name = "semver", marker = "extra == 'test'", specifier = "==3.0.4" },
+    { name = "semver", marker = "extra == 'test'" },
     { name = "yamllint", marker = "extra == 'lint'", specifier = "==1.35.1" },
 ]
 provides-extras = ["lint", "test", "dev"]


### PR DESCRIPTION
**Description of your changes:**
This PR removes pinned versions from test dependencies in `pyproject.toml` and relies on `uv.lock` for reproducibility. It also adds automated checks to ensure the lock file stays in sync with `pyproject.toml`.

### Changes

- **`pyproject.toml`**: Removed version pins from test dependencies (lint deps remain pinned to avoid surprise failures from new lint rules)
- **`.pre-commit-config.yaml`**: Added `uv-lock-check` hook that runs `uv lock --check` when `pyproject.toml` or `uv.lock` is modified
- **`.github/workflows/python-lint.yml`**: Added CI step to verify lock file is in sync
- **`uv.lock`**: Refreshed to reflect the updated constraints

### Why

- Exact versions are tracked in `uv.lock`, making pins in `pyproject.toml` redundant for test deps
- Lint tools are kept pinned because new versions can introduce rule changes that break CI unexpectedly
- Pre-commit + CI checks ensure contributors can't forget to run `uv lock` after updating dependencies

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
