### PR TITLE
feat(ci): add container build matrix check. Fixes #119

### DIFF
--- a/.container-build-ignore
+++ b/.container-build-ignore
@@ -1,0 +1,7 @@
+# List directories containing Containerfiles/Dockerfiles that should NOT
+# be validated against the container-build matrix (e.g. local-dev only)
+#
+# One path per line, relative to the repo root.
+#
+# Example:
+# docs/examples/local-dev

--- a/.container-build-ignore
+++ b/.container-build-ignore
@@ -1,7 +1,0 @@
-# List directories containing Containerfiles/Dockerfiles that should NOT
-# be validated against the container-build matrix (e.g. local-dev only)
-#
-# One path per line, relative to the repo root.
-#
-# Example:
-# docs/examples/local-dev

--- a/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Check that every Containerfile/Dockerfile has a matching entry in container-build.yml.
+
+This ensures contributors do not add a Containerfile without registering it in
+the container-build matrix, which would cause CI to silently skip building it.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+SEARCH_ROOTS = ["components", "pipelines", "docs/examples"]
+CONTAINER_FILENAMES = {"Containerfile", "Dockerfile"}
+IGNORE_FILENAME = ".container-build-ignore"
+WORKFLOW_PATH = ".github/workflows/container-build.yml"
+
+
+def get_repo_root() -> Path:
+    """Locate and return the repository root directory."""
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / ".github").exists():
+            return parent
+    raise RuntimeError("Could not locate repo root")
+
+
+def discover_container_files(repo_root: Path, search_roots: list[str]) -> list[Path]:
+    """Recursively find all Containerfile/Dockerfile paths under search_roots."""
+    found = []
+    for root in search_roots:
+        base = repo_root / root
+        if not base.exists():
+            continue
+        for name in CONTAINER_FILENAMES:
+            found.extend(base.rglob(name))
+    return sorted(found)
+
+
+def load_ignore_list(repo_root: Path) -> set[str]:
+    """Load directories to ignore from IGNORE_FILENAME at the repo root.
+
+    Each non-empty, non-comment line is treated as a path relative to the
+    repo root (e.g. components/foo/bar).
+    """
+    ignore_file = repo_root / IGNORE_FILENAME
+    if not ignore_file.exists():
+        return set()
+    ignored = set()
+    for line in ignore_file.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            ignored.add(str(Path(line)))
+    return ignored
+
+
+def parse_matrix_contexts(workflow_path: Path) -> set[str]:
+    """Extract context values from jobs.build.strategy.matrix.include."""
+    with open(workflow_path) as f:
+        workflow = yaml.safe_load(f)
+
+    includes = workflow.get("jobs", {}).get("build", {}).get("strategy", {}).get("matrix", {}).get("include", [])
+    if not isinstance(includes, list):
+        return set()
+
+    contexts = set()
+    for entry in includes:
+        if "context" in entry:
+            contexts.add(str(Path(entry["context"])))
+    return contexts
+
+
+def check(
+    repo_root: Path,
+    search_roots: list[str],
+    workflow_path: Path,
+) -> tuple[bool, list[dict]]:
+    """Run the matrix check and return (all_matched, results).
+
+    Each result dict has:
+      - file: str path relative to repo root
+      - status: "ok" | "unmatched" | "ignored"
+      - suggestion: str (only present when status == "unmatched")
+    """
+    container_files = discover_container_files(repo_root, search_roots)
+    matrix_contexts = parse_matrix_contexts(workflow_path)
+    ignore_list = load_ignore_list(repo_root)
+
+    results = []
+    all_matched = True
+
+    for cf in container_files:
+        rel_dir = str(cf.parent.relative_to(repo_root))
+
+        if rel_dir in ignore_list:
+            results.append({"file": str(cf.relative_to(repo_root)), "status": "ignored"})
+            continue
+
+        if rel_dir in matrix_contexts:
+            results.append({"file": str(cf.relative_to(repo_root)), "status": "ok"})
+        else:
+            all_matched = False
+            suggestion = f"  - context: {rel_dir}\n    dockerfile: {cf.relative_to(repo_root)}"
+            results.append(
+                {
+                    "file": str(cf.relative_to(repo_root)),
+                    "status": "unmatched",
+                    "suggestion": suggestion,
+                }
+            )
+
+    return all_matched, results
+
+
+def _print_results(results: list[dict], all_matched: bool, workflow_path: str, use_emoji: bool = True) -> None:
+    """Print check results to stdout."""
+    check_icon = "🔍" if use_emoji else "[CHECK]"
+    ok_icon = "✅" if use_emoji else "[OK]"
+    skip_icon = "⏭️" if use_emoji else "[SKIP]"
+    fail_icon = "❌" if use_emoji else "[FAIL]"
+
+    print(f"{check_icon} Checking container build matrix entries in {workflow_path}...")
+
+    unmatched = [r for r in results if r["status"] == "unmatched"]
+    ignored = [r for r in results if r["status"] == "ignored"]
+    ok = [r for r in results if r["status"] == "ok"]
+
+    if ignored:
+        print()
+        for r in ignored:
+            print(f"  {skip_icon} {r['file']} (ignored via {IGNORE_FILENAME})")
+
+    if all_matched:
+        print()
+        print(f"{ok_icon} All Containerfiles/Dockerfiles have a matching matrix entry ({len(ok)} checked)")
+        return
+
+    print()
+    for r in unmatched:
+        print(f"  {fail_icon} {r['file']} has no matching entry in the container-build matrix")
+
+    print()
+    print(f"{fail_icon} Some Containerfiles/Dockerfiles are not registered in the container-build matrix.")
+    print(f"   Add the following entries to the strategy.matrix.include section of {workflow_path}:")
+    print()
+    for r in unmatched:
+        print(r["suggestion"])
+    print()
+    print("   See docs on Adding a Custom Base Image for details.")
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Check that every Containerfile/Dockerfile has a matching container-build matrix entry"
+    )
+    parser.add_argument("--repo-root", default=None, help="Path to the repository root")
+    parser.add_argument("--workflow", default=WORKFLOW_PATH, help="Path to container-build workflow")
+    parser.add_argument("--search-roots", nargs="+", default=SEARCH_ROOTS, help="Directories to scan")
+    parser.add_argument("--no-emoji", action="store_true", help="Disable emoji output")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else get_repo_root()
+    workflow_path = repo_root / args.workflow
+
+    if not workflow_path.exists():
+        print(f"❌ Workflow file not found: {workflow_path}")
+        return 2  # distinct exit code for missing workflow
+
+    all_matched, results = check(repo_root, args.search_roots, workflow_path)
+    _print_results(results, all_matched, args.workflow, use_emoji=not args.no_emoji)
+    return 0 if all_matched else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
@@ -59,13 +59,16 @@ def parse_matrix_contexts(workflow_path: Path) -> set[str]:
     """Extract context values from jobs.build.strategy.matrix.include."""
     with open(workflow_path) as f:
         workflow = yaml.safe_load(f)
-
+    if not isinstance(workflow, dict):
+        return set()
     includes = workflow.get("jobs", {}).get("build", {}).get("strategy", {}).get("matrix", {}).get("include", [])
     if not isinstance(includes, list):
         return set()
 
     contexts = set()
     for entry in includes:
+        if not isinstance(entry, dict):
+            continue
         if "context" in entry:
             contexts.add(str(Path(entry["context"])))
     return contexts
@@ -101,7 +104,11 @@ def check(
             results.append({"file": str(cf.relative_to(repo_root)), "status": "ok"})
         else:
             all_matched = False
-            suggestion = f"  - context: {rel_dir}\n    dockerfile: {cf.relative_to(repo_root)}"
+            suggestion = (
+                "  - name: REPLACE_WITH_UNIQUE_NAME\n"
+                f"    context: {rel_dir}\n"
+                f"    dockerfile: {cf.relative_to(repo_root)}"
+            )
             results.append(
                 {
                     "file": str(cf.relative_to(repo_root)),

--- a/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
@@ -56,11 +56,27 @@ def load_ignore_list(repo_root: Path) -> set[str]:
 
 def parse_matrix_contexts(workflow_path: Path) -> set[str]:
     """Extract context values from jobs.build.strategy.matrix.include."""
-    with open(workflow_path, encoding="utf-8") as f:
-        workflow = yaml.safe_load(f)
+    try:
+        with open(workflow_path, encoding="utf-8") as f:
+            workflow = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        print(f"Error: failed to parse workflow YAML at {workflow_path}: {exc}", file=sys.stderr)
+        return set()
     if not isinstance(workflow, dict):
         return set()
-    includes = workflow.get("jobs", {}).get("build", {}).get("strategy", {}).get("matrix", {}).get("include", [])
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return set()
+    build = jobs.get("build")
+    if not isinstance(build, dict):
+        return set()
+    strategy = build.get("strategy")
+    if not isinstance(strategy, dict):
+        return set()
+    matrix = strategy.get("matrix")
+    if not isinstance(matrix, dict):
+        return set()
+    includes = matrix.get("include", [])
     if not isinstance(includes, list):
         return set()
 
@@ -103,7 +119,8 @@ def check(
             results.append({"file": str(cf.relative_to(repo_root)), "status": "ok"})
         else:
             all_matched = False
-            suggestion = f"  - name: REPLACE_WITH_UNIQUE_NAME\n    context: {rel_dir}"
+            name = rel_dir.replace("/", "-").replace("\\", "-")
+            suggestion = f"        - name: {name}\n          context: {rel_dir}"
             results.append(
                 {
                     "file": str(cf.relative_to(repo_root)),
@@ -149,7 +166,7 @@ def _print_results(results: list[dict], all_matched: bool, workflow_path: str, u
     for r in unmatched:
         print(r["suggestion"])
     print()
-    print("   See docs on Adding a Custom Base Image for details.")
+    print("   See docs/CONTRIBUTING.md#adding-a-custom-base-image for details.")
 
 
 def main() -> int:

--- a/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
@@ -166,7 +166,7 @@ def main() -> int:
     workflow_path = repo_root / args.workflow
 
     if not workflow_path.exists():
-        print(f"❌ Workflow file not found: {workflow_path}")
+        print(f"Workflow file not found: {workflow_path}")
         return 2  # distinct exit code for missing workflow
 
     all_matched, results = check(repo_root, args.search_roots, workflow_path)

--- a/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
@@ -20,9 +20,9 @@ def get_repo_root() -> Path:
     """Locate and return the repository root directory."""
     path = Path(__file__).resolve()
     for parent in path.parents:
-        if (parent / ".github").exists():
+        if (parent / WORKFLOW_PATH).is_file():
             return parent
-    raise RuntimeError("Could not locate repo root")
+    raise RuntimeError(f"Could not locate repo root containing {WORKFLOW_PATH}")
 
 
 def discover_container_files(repo_root: Path, search_roots: list[str]) -> list[Path]:
@@ -99,7 +99,7 @@ def check(
     Each result dict has:
       - file: str path relative to repo root
       - status: "ok" | "unmatched" | "ignored"
-      - suggestion: str (only present when status == "unmatched")
+      - suggestion: str (only present when status == "unmatched" and first file in dir)
     """
     container_files = discover_container_files(repo_root, search_roots)
     matrix_contexts = parse_matrix_contexts(workflow_path)
@@ -107,6 +107,7 @@ def check(
 
     results = []
     all_matched = True
+    seen_dirs: set[str] = set()
 
     for cf in container_files:
         rel_dir = str(cf.parent.relative_to(repo_root))
@@ -120,20 +121,19 @@ def check(
         else:
             all_matched = False
             name = rel_dir.replace("/", "-").replace("\\", "-")
-            # FIX 1: Indentation matches actual container-build.yml (10-space / 12-space)
             suggestion = f"          - name: {name}\n            context: {rel_dir}"
-            results.append(
-                {
-                    "file": str(cf.relative_to(repo_root)),
-                    "status": "unmatched",
-                    "suggestion": suggestion,
-                }
-            )
+            result: dict = {
+                "file": str(cf.relative_to(repo_root)),
+                "status": "unmatched",
+            }
+            if rel_dir not in seen_dirs:
+                result["suggestion"] = suggestion
+                seen_dirs.add(rel_dir)
+            results.append(result)
 
     return all_matched, results
 
 
-# FIX 2: Removed dead use_emoji parameter (--no-emoji flag was removed in earlier review)
 def _print_results(results: list[dict], all_matched: bool, workflow_path: str) -> None:
     """Print check results to stdout."""
     print(f"🔍 Checking container build matrix entries in {workflow_path}...")
@@ -161,7 +161,8 @@ def _print_results(results: list[dict], all_matched: bool, workflow_path: str) -
     print(f"   Add the following entries to the strategy.matrix.include section of {workflow_path}:")
     print()
     for r in unmatched:
-        print(r["suggestion"])
+        if "suggestion" in r:
+            print(r["suggestion"])
     print()
     print("   See docs/CONTRIBUTING.md#adding-a-custom-base-image for details.")
 

--- a/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
@@ -120,7 +120,8 @@ def check(
         else:
             all_matched = False
             name = rel_dir.replace("/", "-").replace("\\", "-")
-            suggestion = f"        - name: {name}\n          context: {rel_dir}"
+            # FIX 1: Indentation matches actual container-build.yml (10-space / 12-space)
+            suggestion = f"          - name: {name}\n            context: {rel_dir}"
             results.append(
                 {
                     "file": str(cf.relative_to(repo_root)),
@@ -132,14 +133,10 @@ def check(
     return all_matched, results
 
 
-def _print_results(results: list[dict], all_matched: bool, workflow_path: str, use_emoji: bool = True) -> None:
+# FIX 2: Removed dead use_emoji parameter (--no-emoji flag was removed in earlier review)
+def _print_results(results: list[dict], all_matched: bool, workflow_path: str) -> None:
     """Print check results to stdout."""
-    check_icon = "🔍" if use_emoji else "[CHECK]"
-    ok_icon = "✅" if use_emoji else "[OK]"
-    skip_icon = "⏭️" if use_emoji else "[SKIP]"
-    fail_icon = "❌" if use_emoji else "[FAIL]"
-
-    print(f"{check_icon} Checking container build matrix entries in {workflow_path}...")
+    print(f"🔍 Checking container build matrix entries in {workflow_path}...")
 
     unmatched = [r for r in results if r["status"] == "unmatched"]
     ignored = [r for r in results if r["status"] == "ignored"]
@@ -148,19 +145,19 @@ def _print_results(results: list[dict], all_matched: bool, workflow_path: str, u
     if ignored:
         print()
         for r in ignored:
-            print(f"  {skip_icon} {r['file']} (ignored via {IGNORE_FILENAME})")
+            print(f"  ⏭️ {r['file']} (ignored via {IGNORE_FILENAME})")
 
     if all_matched:
         print()
-        print(f"{ok_icon} All Containerfiles/Dockerfiles have a matching matrix entry ({len(ok)} checked)")
+        print(f"✅ All Containerfiles/Dockerfiles have a matching matrix entry ({len(ok)} checked)")
         return
 
     print()
     for r in unmatched:
-        print(f"  {fail_icon} {r['file']} has no matching entry in the container-build matrix")
+        print(f"  ❌ {r['file']} has no matching entry in the container-build matrix")
 
     print()
-    print(f"{fail_icon} Some Containerfiles/Dockerfiles are not registered in the container-build matrix.")
+    print("❌ Some Containerfiles/Dockerfiles are not registered in the container-build matrix.")
     print(f"   Add the following entries to the strategy.matrix.include section of {workflow_path}:")
     print()
     for r in unmatched:

--- a/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/check_container_build_matrix.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Check that every Containerfile/Dockerfile has a matching entry in container-build.yml.
 
 This ensures contributors do not add a Containerfile without registering it in
@@ -57,7 +56,7 @@ def load_ignore_list(repo_root: Path) -> set[str]:
 
 def parse_matrix_contexts(workflow_path: Path) -> set[str]:
     """Extract context values from jobs.build.strategy.matrix.include."""
-    with open(workflow_path) as f:
+    with open(workflow_path, encoding="utf-8") as f:
         workflow = yaml.safe_load(f)
     if not isinstance(workflow, dict):
         return set()
@@ -104,11 +103,7 @@ def check(
             results.append({"file": str(cf.relative_to(repo_root)), "status": "ok"})
         else:
             all_matched = False
-            suggestion = (
-                "  - name: REPLACE_WITH_UNIQUE_NAME\n"
-                f"    context: {rel_dir}\n"
-                f"    dockerfile: {cf.relative_to(repo_root)}"
-            )
+            suggestion = f"  - name: REPLACE_WITH_UNIQUE_NAME\n    context: {rel_dir}"
             results.append(
                 {
                     "file": str(cf.relative_to(repo_root)),
@@ -165,7 +160,6 @@ def main() -> int:
     parser.add_argument("--repo-root", default=None, help="Path to the repository root")
     parser.add_argument("--workflow", default=WORKFLOW_PATH, help="Path to container-build workflow")
     parser.add_argument("--search-roots", nargs="+", default=SEARCH_ROOTS, help="Directories to scan")
-    parser.add_argument("--no-emoji", action="store_true", help="Disable emoji output")
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve() if args.repo_root else get_repo_root()
@@ -176,7 +170,7 @@ def main() -> int:
         return 2  # distinct exit code for missing workflow
 
     all_matched, results = check(repo_root, args.search_roots, workflow_path)
-    _print_results(results, all_matched, args.workflow, use_emoji=not args.no_emoji)
+    _print_results(results, all_matched, args.workflow)
     return 0 if all_matched else 1
 
 

--- a/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
@@ -23,7 +23,7 @@ def _write(path: Path, content: str) -> Path:
 
 
 def _make_workflow(tmp_path: Path, contexts: list[str]) -> Path:
-    includes = "\n".join(f"        - context: {ctx}\n          dockerfile: {ctx}/Containerfile" for ctx in contexts)
+    includes = "\n".join(f"        - name: {ctx}\n          context: {ctx}" for ctx in contexts)
     content = f"""\
 jobs:
   build:

--- a/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
@@ -1,0 +1,209 @@
+"""Unit tests for check_container_build_matrix."""
+
+import textwrap
+from pathlib import Path
+
+from ..check_container_build_matrix import (
+    IGNORE_FILENAME,
+    check,
+    discover_container_files,
+    load_ignore_list,
+    parse_matrix_contexts,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+def _make_workflow(tmp_path: Path, contexts: list[str]) -> Path:
+    includes = "\n".join(f"        - context: {ctx}\n          dockerfile: {ctx}/Containerfile" for ctx in contexts)
+    content = f"""\
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+{includes}
+"""
+    return _write(tmp_path / ".github/workflows/container-build.yml", content)
+
+
+# ---------------------------------------------------------------------------
+# discover_container_files
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverContainerFiles:
+    """Tests for discover_container_files."""
+
+    def test_finds_containerfile(self, tmp_path):
+        """Finds a Containerfile under a search root."""
+        _write(tmp_path / "components/cat/comp/Containerfile", "FROM python:3.11")
+        results = discover_container_files(tmp_path, ["components"])
+        assert any("Containerfile" in str(r) for r in results)
+
+    def test_finds_dockerfile(self, tmp_path):
+        """Finds a Dockerfile under a search root."""
+        _write(tmp_path / "components/cat/comp/Dockerfile", "FROM python:3.11")
+        results = discover_container_files(tmp_path, ["components"])
+        assert any("Dockerfile" in str(r) for r in results)
+
+    def test_finds_nested_subcategory(self, tmp_path):
+        """Finds a Containerfile nested under a subcategory."""
+        _write(tmp_path / "components/cat/subcat/comp/Containerfile", "FROM python:3.11")
+        results = discover_container_files(tmp_path, ["components"])
+        assert len(results) == 1
+
+    def test_missing_root_is_skipped(self, tmp_path):
+        """Returns empty list when search root does not exist."""
+        results = discover_container_files(tmp_path, ["nonexistent"])
+        assert results == []
+
+    def test_multiple_roots(self, tmp_path):
+        """Finds container files across multiple search roots."""
+        _write(tmp_path / "components/cat/a/Containerfile", "FROM a")
+        _write(tmp_path / "pipelines/cat/b/Containerfile", "FROM b")
+        results = discover_container_files(tmp_path, ["components", "pipelines"])
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# parse_matrix_contexts
+# ---------------------------------------------------------------------------
+
+
+class TestParseMatrixContexts:
+    """Tests for parse_matrix_contexts."""
+
+    def test_extracts_contexts(self, tmp_path):
+        """Extracts context paths from the matrix workflow file."""
+        wf = _make_workflow(tmp_path, ["components/cat/comp", "pipelines/cat/pipe"])
+        contexts = parse_matrix_contexts(wf)
+        contexts_normalized = {c.replace("\\", "/") for c in contexts}
+        assert "components/cat/comp" in contexts_normalized
+        assert "pipelines/cat/pipe" in contexts_normalized
+
+    def test_empty_matrix(self, tmp_path):
+        """Returns empty set when matrix include list is empty."""
+        wf = _write(
+            tmp_path / ".github/workflows/container-build.yml",
+            """\
+            jobs:
+              build:
+                strategy:
+                  matrix:
+                    include: []
+            """,
+        )
+        assert parse_matrix_contexts(wf) == set()
+
+    def test_missing_matrix_key(self, tmp_path):
+        """Returns empty set when matrix key is missing."""
+        wf = _write(
+            tmp_path / ".github/workflows/container-build.yml",
+            "jobs:\n  build:\n    steps: []\n",
+        )
+        assert parse_matrix_contexts(wf) == set()
+
+
+# ---------------------------------------------------------------------------
+# load_ignore_list
+# ---------------------------------------------------------------------------
+
+
+class TestLoadIgnoreList:
+    """Tests for load_ignore_list."""
+
+    def test_loads_paths(self, tmp_path):
+        """Loads paths from the ignore file."""
+        (tmp_path / IGNORE_FILENAME).write_text("components/foo/bar\npipelines/baz\n")
+        result = load_ignore_list(tmp_path)
+        result_normalized = {p.replace("\\", "/") for p in result}
+        assert "components/foo/bar" in result_normalized
+        assert "pipelines/baz" in result_normalized
+
+    def test_ignores_comments_and_blank_lines(self, tmp_path):
+        """Skips comments and blank lines in the ignore file."""
+        (tmp_path / IGNORE_FILENAME).write_text("# comment\n\ncomponents/foo\n")
+        result = load_ignore_list(tmp_path)
+        result_normalized = {p.replace("\\", "/") for p in result}
+        assert result_normalized == {"components/foo"}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Returns empty set when ignore file does not exist."""
+        assert load_ignore_list(tmp_path) == set()
+
+
+# ---------------------------------------------------------------------------
+# check (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestCheck:
+    """Integration tests for check."""
+
+    def test_all_matched(self, tmp_path):
+        """Passes when all container files have a matrix entry."""
+        _write(tmp_path / "components/cat/comp/Containerfile", "FROM python:3.11")
+        wf = _make_workflow(tmp_path, ["components/cat/comp"])
+        all_matched, results = check(tmp_path, ["components"], wf)
+        assert all_matched
+        assert results[0]["status"] == "ok"
+
+    def test_unmatched_fails(self, tmp_path):
+        """Fails when a container file has no matrix entry."""
+        _write(tmp_path / "components/cat/comp/Containerfile", "FROM python:3.11")
+        wf = _make_workflow(tmp_path, [])
+        all_matched, results = check(tmp_path, ["components"], wf)
+        assert not all_matched
+        assert results[0]["status"] == "unmatched"
+        assert "suggestion" in results[0]
+
+    def test_suggestion_contains_context(self, tmp_path):
+        """Suggestion includes the correct context path."""
+        _write(tmp_path / "components/cat/comp/Containerfile", "FROM python:3.11")
+        wf = _make_workflow(tmp_path, [])
+        _, results = check(tmp_path, ["components"], wf)
+        suggestion_normalized = results[0]["suggestion"].replace("\\", "/")
+        assert "components/cat/comp" in suggestion_normalized
+
+    def test_ignored_path_is_skipped(self, tmp_path):
+        """Skips container files listed in the ignore file."""
+        _write(tmp_path / "components/cat/comp/Containerfile", "FROM python:3.11")
+        (tmp_path / IGNORE_FILENAME).write_text("components/cat/comp\n")
+        wf = _make_workflow(tmp_path, [])
+        all_matched, results = check(tmp_path, ["components"], wf)
+        assert all_matched
+        assert results[0]["status"] == "ignored"
+
+    def test_subcategory_path_matched(self, tmp_path):
+        """Passes when a subcategory container file has a matrix entry."""
+        _write(tmp_path / "components/cat/subcat/comp/Containerfile", "FROM python:3.11")
+        wf = _make_workflow(tmp_path, ["components/cat/subcat/comp"])
+        all_matched, results = check(tmp_path, ["components"], wf)
+        assert all_matched
+
+    def test_missing_and_present_mixed(self, tmp_path):
+        """Reports ok and unmatched correctly when results are mixed."""
+        _write(tmp_path / "components/cat/a/Containerfile", "FROM a")
+        _write(tmp_path / "components/cat/b/Containerfile", "FROM b")
+        wf = _make_workflow(tmp_path, ["components/cat/a"])
+        all_matched, results = check(tmp_path, ["components"], wf)
+        assert not all_matched
+        statuses = {r["file"].replace("\\", "/").split("/")[-2]: r["status"] for r in results}
+        assert statuses["a"] == "ok"
+        assert statuses["b"] == "unmatched"
+
+    def test_no_container_files_passes(self, tmp_path):
+        """Passes when no container files are found."""
+        wf = _make_workflow(tmp_path, [])
+        all_matched, results = check(tmp_path, ["components"], wf)
+        assert all_matched
+        assert results == []

--- a/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
@@ -112,6 +112,39 @@ class TestParseMatrixContexts:
         )
         assert parse_matrix_contexts(wf) == set()
 
+    # FIX 3a: New test — malformed YAML triggers yaml.YAMLError
+    def test_invalid_yaml_returns_empty(self, tmp_path):
+        """Returns empty set when YAML is malformed."""
+        wf = _write(tmp_path / ".github/workflows/container-build.yml", ": : :\n  - [")
+        assert parse_matrix_contexts(wf) == set()
+
+    # FIX 3b: New test — empty file causes yaml.safe_load to return None
+    def test_null_yaml_returns_empty(self, tmp_path):
+        """Returns empty set when YAML file is empty."""
+        wf = _write(tmp_path / ".github/workflows/container-build.yml", "")
+        assert parse_matrix_contexts(wf) == set()
+
+    # FIX 3c: New test — non-dict entries in include list are skipped
+    def test_non_dict_include_entry_skipped(self, tmp_path):
+        """Skips non-dict entries in the include list."""
+        wf = _write(
+            tmp_path / ".github/workflows/container-build.yml",
+            """\
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - null
+          - name: valid
+            context: components/valid
+""",
+        )
+        contexts = parse_matrix_contexts(wf)
+        contexts_normalized = {c.replace("\\", "/") for c in contexts}
+        assert len(contexts_normalized) == 1
+        assert "components/valid" in contexts_normalized
+
 
 # ---------------------------------------------------------------------------
 # load_ignore_list
@@ -167,12 +200,15 @@ class TestCheck:
         assert "suggestion" in results[0]
 
     def test_suggestion_contains_context(self, tmp_path):
-        """Suggestion includes the correct context path."""
+        """Suggestion includes the correct context path and proper indentation."""
         _write(tmp_path / "components/cat/comp/Containerfile", "FROM python:3.11")
         wf = _make_workflow(tmp_path, [])
         _, results = check(tmp_path, ["components"], wf)
         suggestion_normalized = results[0]["suggestion"].replace("\\", "/")
         assert "components/cat/comp" in suggestion_normalized
+        # Verify indentation matches container-build.yml (10-space for -, 12-space for context)
+        assert "          - name:" in suggestion_normalized
+        assert "            context:" in suggestion_normalized
 
     def test_ignored_path_is_skipped(self, tmp_path):
         """Skips container files listed in the ignore file."""

--- a/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
+++ b/.github/scripts/check_container_build_matrix/tests/test_check_container_build_matrix.py
@@ -112,19 +112,16 @@ class TestParseMatrixContexts:
         )
         assert parse_matrix_contexts(wf) == set()
 
-    # FIX 3a: New test — malformed YAML triggers yaml.YAMLError
     def test_invalid_yaml_returns_empty(self, tmp_path):
         """Returns empty set when YAML is malformed."""
         wf = _write(tmp_path / ".github/workflows/container-build.yml", ": : :\n  - [")
         assert parse_matrix_contexts(wf) == set()
 
-    # FIX 3b: New test — empty file causes yaml.safe_load to return None
     def test_null_yaml_returns_empty(self, tmp_path):
         """Returns empty set when YAML file is empty."""
         wf = _write(tmp_path / ".github/workflows/container-build.yml", "")
         assert parse_matrix_contexts(wf) == set()
 
-    # FIX 3c: New test — non-dict entries in include list are skipped
     def test_non_dict_include_entry_skipped(self, tmp_path):
         """Skips non-dict entries in the include list."""
         wf = _write(
@@ -206,7 +203,6 @@ class TestCheck:
         _, results = check(tmp_path, ["components"], wf)
         suggestion_normalized = results[0]["suggestion"].replace("\\", "/")
         assert "components/cat/comp" in suggestion_normalized
-        # Verify indentation matches container-build.yml (10-space for -, 12-space for context)
         assert "          - name:" in suggestion_normalized
         assert "            context:" in suggestion_normalized
 
@@ -243,3 +239,13 @@ class TestCheck:
         all_matched, results = check(tmp_path, ["components"], wf)
         assert all_matched
         assert results == []
+
+    def test_duplicate_suggestion_not_emitted(self, tmp_path):
+        """When both Containerfile and Dockerfile exist in same dir, suggestion shown once."""
+        _write(tmp_path / "components/cat/comp/Containerfile", "FROM python:3.11")
+        _write(tmp_path / "components/cat/comp/Dockerfile", "FROM python:3.11")
+        wf = _make_workflow(tmp_path, [])
+        all_matched, results = check(tmp_path, ["components"], wf)
+        assert not all_matched
+        suggestions = [r for r in results if "suggestion" in r]
+        assert len(suggestions) == 1

--- a/.github/workflows/container-build-matrix-check.yml
+++ b/.github/workflows/container-build-matrix-check.yml
@@ -8,25 +8,22 @@ on:
       - "**/Dockerfile"
       - ".github/workflows/container-build.yml"
       - ".github/scripts/check_container_build_matrix/**"
-
+      - ".container-build-ignore"
 jobs:
-  check-matrix:
+  check-container-build-matrix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-ci
         with:
           python-version: "3.11"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-
-      - name: Run matrix check unit tests
+      - name: Run matrix check script
         run: uv run python -m check_container_build_matrix.check_container_build_matrix
         working-directory: .github/scripts
 
-      - name: Run unit tests
-        run: pytest -v
+      - name: Run unit tests with pytest
+        run: uv run pytest -v
         working-directory: .github/scripts

--- a/.github/workflows/container-build-matrix-check.yml
+++ b/.github/workflows/container-build-matrix-check.yml
@@ -1,0 +1,32 @@
+---
+name: Check Container Build Matrix
+
+on:
+  pull_request:
+    paths:
+      - "**/Containerfile"
+      - "**/Dockerfile"
+      - ".github/workflows/container-build.yml"
+      - ".github/scripts/check_container_build_matrix/**"
+
+jobs:
+  check-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Run matrix check unit tests
+        run: uv run python -m check_container_build_matrix.check_container_build_matrix
+        working-directory: .github/scripts
+
+      - name: Run unit tests
+        run: pytest -v
+        working-directory: .github/scripts

--- a/.github/workflows/container-build-matrix-check.yml
+++ b/.github/workflows/container-build-matrix-check.yml
@@ -8,12 +8,12 @@ on:
       - "**/Dockerfile"
       - ".github/workflows/container-build.yml"
       - ".github/scripts/check_container_build_matrix/**"
-      - ".container-build-ignore"
+      - ".github/workflows/container-build-matrix-check.yml"
 jobs:
   check-container-build-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-ci
@@ -22,8 +22,4 @@ jobs:
 
       - name: Run matrix check script
         run: uv run python -m check_container_build_matrix.check_container_build_matrix
-        working-directory: .github/scripts
-
-      - name: Run unit tests with pytest
-        run: uv run pytest -v
         working-directory: .github/scripts

--- a/.github/workflows/container-build-matrix-check.yml
+++ b/.github/workflows/container-build-matrix-check.yml
@@ -8,8 +8,6 @@ on:
       - "components/**/Dockerfile"
       - "pipelines/**/Containerfile"
       - "pipelines/**/Dockerfile"
-      - "docs/examples/**/Containerfile"
-      - "docs/examples/**/Dockerfile"
       - ".container-build-ignore"
       - ".github/workflows/container-build.yml"
       - ".github/scripts/check_container_build_matrix/**"
@@ -19,7 +17,7 @@ jobs:
   check-container-build-matrix:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-ci

--- a/.github/workflows/container-build-matrix-check.yml
+++ b/.github/workflows/container-build-matrix-check.yml
@@ -4,17 +4,22 @@ name: Check Container Build Matrix
 on:
   pull_request:
     paths:
-      - "**/Containerfile"
-      - "**/Dockerfile"
+      - "components/**/Containerfile"
+      - "components/**/Dockerfile"
+      - "pipelines/**/Containerfile"
+      - "pipelines/**/Dockerfile"
+      - "docs/examples/**/Containerfile"
+      - "docs/examples/**/Dockerfile"
       - ".container-build-ignore"
       - ".github/workflows/container-build.yml"
       - ".github/scripts/check_container_build_matrix/**"
       - ".github/workflows/container-build-matrix-check.yml"
+
 jobs:
   check-container-build-matrix:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
 
       - name: Set up Python and uv
         uses: ./.github/actions/setup-python-ci

--- a/.github/workflows/container-build-matrix-check.yml
+++ b/.github/workflows/container-build-matrix-check.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**/Containerfile"
       - "**/Dockerfile"
+      - ".container-build-ignore"
       - ".github/workflows/container-build.yml"
       - ".github/scripts/check_container_build_matrix/**"
       - ".github/workflows/container-build-matrix-check.yml"


### PR DESCRIPTION
## Description of your changes

Implements the CI check proposed in #119.

- Added `.github/scripts/check_container_build_matrix/` script that 
  recursively discovers all Containerfile/Dockerfile paths under 
  `components/`, `pipelines/`, and `docs/examples/`, and validates 
  each has a matching context entry in `container-build.yml`
- Added `.github/workflows/container-build-matrix-check.yml` workflow 
  that triggers on PRs touching `**/Containerfile`, `**/Dockerfile`, 
  or `container-build.yml`
- Added 18 unit tests following `.github/scripts/` conventions

## Checklist
- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have signed off your commits