### PR TITLE
fix(ci): regenerate stale golden READMEs and trigger tests on test_data changes

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -9,11 +9,11 @@ on:
     paths:
       - '.github/scripts/**'
       - 'scripts/**'
+      - 'test_data/**'
       - '.github/workflows/scripts-tests.yml'
       - '.github/actions/setup-python-ci/**'
       - 'pyproject.toml'
       - 'uv.lock'
-      - '!**/OWNERS'
 
 jobs:
   test-scripts:

--- a/test_data/components/grouped/ml_models/linear_model/README.md
+++ b/test_data/components/grouped/ml_models/linear_model/README.md
@@ -52,3 +52,5 @@ def example_pipeline(data_path: str = "/data/train.csv", target_col: str = "pric
   - Approvers:
     - nsingla
     - hbelmiro
+  - Reviewers:
+    - nsingla

--- a/test_data/pipelines/grouped/etl_flows/daily_ingest/README.md
+++ b/test_data/pipelines/grouped/etl_flows/daily_ingest/README.md
@@ -25,3 +25,5 @@ This pipeline orchestrates the daily ingestion of data from an external source i
   - Approvers:
     - nsingla
     - hbelmiro
+  - Reviewers:
+    - nsingla


### PR DESCRIPTION
## Summary

- Regenerate golden READMEs for grouped/subcategory test fixtures that were out of sync since `ffaeb55` added `reviewers` to OWNERS files without regenerating the READMEs
- Add `test_data/**` to `scripts-tests.yml` pull_request path triggers so future test data changes (OWNERS, metadata, etc.) run the integration tests that depend on them
- Remove `!**/OWNERS` exclusion from `scripts-tests.yml` so OWNERS changes are no longer silently skipped

## Context

The generate_readme integration tests have been broken on `main` since #161, but the breakage was invisible because `scripts-tests.yml` doesn't trigger on `test_data/**` changes. Any unrelated PR that touches `scripts/**` or `pyproject.toml` (e.g. #180) gets blamed for the pre-existing failure.

## Test plan

- [x] All 12 `generate_readme` integration tests pass locally